### PR TITLE
Fix Nexus SSO after registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ CMakeCache.txt
 CMakeFiles/
 cmake_install.cmake
 CTestTestfile.cmake
-Makefile
 *.cmake
 
 # Keep CMakeLists.txt and presets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(TrenchKit
-  VERSION 1.0.1
+  VERSION 1.1.0
   LANGUAGES CXX
 )
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+# Simple Makefile wrapper for CMake/Ninja workflows
+
+BUILD_DIR_DEBUG=build/debug
+BUILD_DIR_RELEASE=build/release
+GENERATOR=Ninja
+
+.PHONY: all configure-debug configure-release build-debug build-release test test-debug run-debug run-release clean
+
+all: build-debug
+
+configure-debug:
+	cmake -S . -B $(BUILD_DIR_DEBUG) -G $(GENERATOR) -DCMAKE_BUILD_TYPE=Debug
+
+configure-release:
+	cmake -S . -B $(BUILD_DIR_RELEASE) -G $(GENERATOR) -DCMAKE_BUILD_TYPE=Release
+
+build-debug: configure-debug
+	cmake --build $(BUILD_DIR_DEBUG)
+
+build-release: configure-release
+	cmake --build $(BUILD_DIR_RELEASE)
+	python tools/package_release.py --build-dir $(BUILD_DIR_RELEASE)
+
+test: test-debug
+
+test-debug: build-debug
+	ctest --test-dir $(BUILD_DIR_DEBUG) --output-on-failure
+
+run-debug: build-debug
+	$(BUILD_DIR_DEBUG)/TrenchKit.exe
+
+run-release: build-release
+	$(BUILD_DIR_RELEASE)/TrenchKit.exe
+
+clean:
+	cmake --build $(BUILD_DIR_DEBUG) --target clean || true
+	cmake --build $(BUILD_DIR_RELEASE) --target clean || true

--- a/README.md
+++ b/README.md
@@ -35,6 +35,49 @@
 - Install mod from Itch.io
 - Check for mod updates
 
+## Usage Guide
+
+### Installing Mods from NexusMods or Itch.io
+
+1. Click the **"Add Mod"** button
+2. Select **"Download from NexusMods"** or **"Download from Itch.io"**
+3. Authenticate with the platform (see Authentication section below)
+4. Enter the mod URL and follow the prompts
+
+**Why download through TrenchKit?** Mods downloaded using the Add Mod button automatically store metadata (mod ID, file ID, and source information) which enables the **Check for Updates** feature.
+
+### Checking for Mod Updates
+
+Click the **"Check for Updates"** button to see if newer versions are available for your installed mods.
+
+**Important:** The update checker only works for mods that have source metadata. This means:
+- ✅ Mods downloaded through the Add Mod button (NexusMods/Itch.io)
+- ✅ Manually installed mods with metadata added via "Edit Metadata" (right-click mod)
+- ❌ Manually installed `.pak` files without metadata
+
+To enable updates for manually installed mods, right-click the mod and select **"Edit Metadata"** to add the NexusMods or Itch.io information.
+
+### Authentication
+
+#### NexusMods (SSO)
+TrenchKit uses NexusMods Single Sign-On (SSO) authentication:
+1. Go to **Settings** → **NexusMods Integration**
+2. Click **"Authenticate (SSO)"**
+3. Your browser will open to the NexusMods authorization page
+4. Click **"Authorize"** to grant TrenchKit access
+5. The authentication will complete automatically
+
+#### Itch.io (API Key)
+To download mods from Itch.io, you need an API key:
+
+1. Visit [itch.io API Keys page](https://itch.io/user/settings/api-keys)
+2. Click **"Generate new API key"**
+3. Copy the generated key
+4. In TrenchKit, go to **Settings** → **Itch.io Integration**
+5. Click **"Add API Key"** and paste your key
+
+**Note:** Keep your API key private. It grants access to your itch.io account.
+
 ## Planned Features
 - Create mod development environment
 - Bundle mod development tools ([UE Viewer](https://github.com/gildor2/UEViewer))

--- a/src/modals/content/NexusDownloadModalContent.cpp
+++ b/src/modals/content/NexusDownloadModalContent.cpp
@@ -41,9 +41,9 @@ NexusDownloadModalContent::NexusDownloadModalContent(NexusModsClient *client,
     connect(m_client, &NexusModsClient::downloadFinished, this, &NexusDownloadModalContent::onDownloadFinished);
     connect(m_client, &NexusModsClient::errorOccurred, this, &NexusDownloadModalContent::onError);
 
-    connect(m_auth, &NexusModsAuth::authenticationStarted, this, &NexusDownloadModalContent::onAuthStarted);
-    connect(m_auth, &NexusModsAuth::authenticationComplete, this, &NexusDownloadModalContent::onAuthComplete);
-    connect(m_auth, &NexusModsAuth::authenticationFailed, this, &NexusDownloadModalContent::onAuthFailed);
+    connect(m_auth, &NexusModsAuth::authenticationStarted, this, &NexusDownloadModalContent::onAuthStarted, Qt::UniqueConnection);
+    connect(m_auth, &NexusModsAuth::authenticationComplete, this, &NexusDownloadModalContent::onAuthComplete, Qt::UniqueConnection);
+    connect(m_auth, &NexusModsAuth::authenticationFailed, this, &NexusDownloadModalContent::onAuthFailed, Qt::UniqueConnection);
 }
 
 void NexusDownloadModalContent::setupUi() {

--- a/src/utils/NexusModsAuth.cpp
+++ b/src/utils/NexusModsAuth.cpp
@@ -3,23 +3,30 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QRandomGenerator>
+#include <QDebug>
 
 NexusModsAuth::NexusModsAuth(QObject *parent)
     : QObject(parent)
 {
     connect(&m_socket, &QWebSocket::connected, this, &NexusModsAuth::onConnected);
     connect(&m_socket, &QWebSocket::textMessageReceived, this, &NexusModsAuth::onTextMessageReceived);
+    connect(&m_socket, &QWebSocket::disconnected, this, &NexusModsAuth::onDisconnected);
     connect(&m_socket, &QWebSocket::errorOccurred, this, &NexusModsAuth::onError);
 }
 
 void NexusModsAuth::startAuthentication() {
     if (m_isAuthenticating) {
+        qDebug() << "[NexusAuth] Already authenticating, ignoring request";
         return;
     }
 
+    qDebug() << "[NexusAuth] Starting authentication";
     m_isAuthenticating = true;
     m_uuid = QUuid::createUuid().toString(QUuid::WithoutBraces);
     m_token = generateConnectionToken();
+
+    qDebug() << "[NexusAuth] UUID:" << m_uuid;
+    qDebug() << "[NexusAuth] Opening WebSocket to wss://sso.nexusmods.com";
 
     QUrl wsUrl(QStringLiteral("wss://sso.nexusmods.com"));
     m_socket.open(wsUrl);
@@ -35,22 +42,28 @@ void NexusModsAuth::cancelAuthentication() {
 }
 
 void NexusModsAuth::onConnected() {
+    qDebug() << "[NexusAuth] WebSocket connected";
     QJsonObject connectionMessage;
     connectionMessage[QStringLiteral("id")] = m_uuid;
     connectionMessage[QStringLiteral("token")] = m_token;
     connectionMessage[QStringLiteral("protocol")] = 2;
 
     QJsonDocument doc(connectionMessage);
-    m_socket.sendTextMessage(doc.toJson(QJsonDocument::Compact));
+    QString jsonMsg = doc.toJson(QJsonDocument::Compact);
+    qDebug() << "[NexusAuth] Sending connection message:" << jsonMsg;
+    m_socket.sendTextMessage(jsonMsg);
 
-    QString browserUrl = QStringLiteral("https://www.nexusmods.com/sso?id=%1&application=trenchkit")
+    QString browserUrl = QStringLiteral("https://www.nexusmods.com/sso?id=%1&application=tapawingo-trenchkit")
                             .arg(m_uuid);
+    qDebug() << "[NexusAuth] Browser URL:" << browserUrl;
     emit authenticationStarted(browserUrl);
 }
 
 void NexusModsAuth::onTextMessageReceived(const QString &message) {
+    qDebug() << "[NexusAuth] Received message:" << message;
     QJsonDocument doc = QJsonDocument::fromJson(message.toUtf8());
     if (doc.isNull() || !doc.isObject()) {
+        qDebug() << "[NexusAuth] Invalid JSON received";
         emit authenticationFailed(QStringLiteral("Invalid response from authentication server"));
         cleanup();
         return;
@@ -58,24 +71,51 @@ void NexusModsAuth::onTextMessageReceived(const QString &message) {
 
     QJsonObject obj = doc.object();
     if (obj.contains(QStringLiteral("success")) && obj[QStringLiteral("success")].toBool()) {
-        QString apiKey = obj[QStringLiteral("data")].toObject()[QStringLiteral("api_key")].toString();
+        qDebug() << "[NexusAuth] Success response received";
+        QJsonObject data = obj[QStringLiteral("data")].toObject();
+
+        // Check if this is the connection acknowledgment or the actual authentication result
+        if (data.contains(QStringLiteral("connection_token"))) {
+            qDebug() << "[NexusAuth] Connection acknowledged, waiting for user authorization...";
+            // This is just the connection acknowledgment, keep waiting for the actual API key
+            return;
+        }
+
+        QString apiKey = data[QStringLiteral("api_key")].toString();
         if (apiKey.isEmpty()) {
-            emit authenticationFailed(QStringLiteral("No API key received"));
+            qDebug() << "[NexusAuth] API key is empty in authentication response";
+            emit authenticationFailed(QStringLiteral("No API key received from server"));
             cleanup();
             return;
         }
 
+        qDebug() << "[NexusAuth] Authentication complete with API key";
         emit authenticationComplete(apiKey);
         cleanup();
     } else if (obj.contains(QStringLiteral("error"))) {
         QString error = obj[QStringLiteral("error")].toString();
+        qDebug() << "[NexusAuth] Error response:" << error;
         emit authenticationFailed(error.isEmpty() ? QStringLiteral("Authentication failed") : error);
         cleanup();
+    } else {
+        // Received a message but it wasn't success or error - might be a connection acknowledgment
+        qDebug() << "[NexusAuth] Non-success/error message, waiting for actual response";
     }
 }
 
+void NexusModsAuth::onDisconnected() {
+    qDebug() << "[NexusAuth] WebSocket disconnected, authenticating:" << m_isAuthenticating;
+    if (!m_isAuthenticating) {
+        return;
+    }
+
+    qDebug() << "[NexusAuth] Unexpected disconnect during authentication";
+    emit authenticationFailed(QStringLiteral("Connection to authentication server was closed unexpectedly"));
+    cleanup();
+}
+
 void NexusModsAuth::onError(QAbstractSocket::SocketError error) {
-    Q_UNUSED(error);
+    qDebug() << "[NexusAuth] WebSocket error:" << error << m_socket.errorString();
     if (!m_isAuthenticating) {
         return;
     }
@@ -85,8 +125,10 @@ void NexusModsAuth::onError(QAbstractSocket::SocketError error) {
 }
 
 void NexusModsAuth::cleanup() {
+    qDebug() << "[NexusAuth] Cleanup called, socket state:" << m_socket.state();
     m_isAuthenticating = false;
     if (m_socket.state() == QAbstractSocket::ConnectedState) {
+        qDebug() << "[NexusAuth] Closing WebSocket connection";
         m_socket.close();
     }
     m_uuid.clear();

--- a/src/utils/NexusModsAuth.h
+++ b/src/utils/NexusModsAuth.h
@@ -24,6 +24,7 @@ signals:
 private slots:
     void onConnected();
     void onTextMessageReceived(const QString &message);
+    void onDisconnected();
     void onError(QAbstractSocket::SocketError error);
 
 private:

--- a/src/widgets/ModRowWidget.cpp
+++ b/src/widgets/ModRowWidget.cpp
@@ -61,8 +61,8 @@ void ModRowWidget::setupUi(const ModInfo &mod) {
 
     setProperty("selected", false);
 
-    connect(m_enabledCheckBox, &QCheckBox::checkStateChanged,
-            this, [this](Qt::CheckState state) {
+    connect(m_enabledCheckBox, &QCheckBox::stateChanged,
+            this, [this](int state) {
         emit enabledChanged(m_modId, state == Qt::Checked);
     });
 


### PR DESCRIPTION
When merged this PR will:
- Fix Nexusmods SSO integration after completed registration
- Remove manual API key entry for Nexusmods (for Application registration acceptence criteria)
- Add Usage section in the Readme