### PR TITLE
Add visualization of overwritten files and mods

### DIFF
--- a/src/utils/ModConflictDetector.cpp
+++ b/src/utils/ModConflictDetector.cpp
@@ -179,15 +179,22 @@ ModConflictDetector::ScanResult ModConflictDetector::detectConflictsWorker(const
                 return a->priority < b->priority;
             });
 
+        const QString &conflictingFile = it.key();
+        const ModFileCache *winnerMod = modList.last();
+
         for (const ModFileCache *mod : modList) {
             ConflictInfo &info = result.conflicts[mod->modId];
             info.modPriority = mod->priority;
             info.fileConflictCount++;
 
-            info.allConflictingFilePaths.append(it.key());
+            info.allConflictingFilePaths.append(conflictingFile);
+
+            if (mod != winnerMod) {
+                info.overwrittenFilePaths.insert(conflictingFile);
+            }
 
             if (info.conflictingFilePaths.size() < 100) {
-                info.conflictingFilePaths.append(it.key());
+                info.conflictingFilePaths.append(conflictingFile);
             }
 
             for (const ModFileCache *otherMod : modList) {

--- a/src/utils/ModConflictDetector.h
+++ b/src/utils/ModConflictDetector.h
@@ -5,6 +5,7 @@
 #include <QString>
 #include <QMap>
 #include <QStringList>
+#include <QSet>
 #include <QFutureWatcher>
 #include <QMutex>
 #include <QDateTime>
@@ -17,9 +18,14 @@ struct ConflictInfo {
     QList<int> conflictingModPriorities;
     QStringList conflictingFilePaths;
     QStringList allConflictingFilePaths;
+    QSet<QString> overwrittenFilePaths;
     int fileConflictCount = 0;
 
     bool hasConflicts() const { return !conflictingModIds.isEmpty(); }
+    bool isEntirelyOverwritten() const {
+        return !overwrittenFilePaths.isEmpty() &&
+               overwrittenFilePaths.size() == fileConflictCount;
+    }
 };
 
 class ModManager;

--- a/src/widgets/ModRowWidget.cpp
+++ b/src/widgets/ModRowWidget.cpp
@@ -211,12 +211,19 @@ void ModRowWidget::setConflictInfo(const ConflictInfo &info) {
             m_conflictTooltip->setText(m_conflictTooltipText);
         }
 
+        if (info.isEntirelyOverwritten()) {
+            m_nameLabel->setStyleSheet("QLabel#modNameLabel { color: #f48771; }");
+        } else {
+            m_nameLabel->setStyleSheet("");
+        }
+
         int buttonHeight = m_conflictButton->height();
         if (buttonHeight > 0) {
             m_conflictButton->setFixedWidth(buttonHeight);
         }
     } else {
         m_conflictTooltipText.clear();
+        m_nameLabel->setStyleSheet("");
         if (m_conflictTooltip) {
             m_conflictTooltip->hide();
         }
@@ -228,6 +235,7 @@ void ModRowWidget::clearConflictIndicator() {
         m_conflictButton->setVisible(false);
     }
     m_conflictTooltipText.clear();
+    m_nameLabel->setStyleSheet("");
     if (m_conflictTooltip) {
         m_conflictTooltip->hide();
     }
@@ -245,20 +253,32 @@ QString ModRowWidget::formatConflictTooltip(const ConflictInfo &info) const {
         int otherPriority = info.conflictingModPriorities[i];
 
         QString loadOrder;
+        QString color = "";
+
         if (otherPriority < info.modPriority) {
             loadOrder = " <i>(loads before this)</i>";
         } else {
             loadOrder = " <i>(loads after this)</i>";
+            if (info.isEntirelyOverwritten()) {
+                color = " style='color: #f48771;'";
+            }
         }
 
-        tooltip += QString("• %1%2<br>").arg(modName, loadOrder);
+        tooltip += QString("• <span%1>%2</span>%3<br>").arg(color, modName, loadOrder);
     }
 
     if (!info.conflictingFilePaths.isEmpty()) {
         tooltip += "<br><b>Sample conflicts:</b><br>";
         int sampleCount = qMin(5, info.conflictingFilePaths.size());
         for (int i = 0; i < sampleCount; ++i) {
-            tooltip += QString("• %1<br>").arg(info.conflictingFilePaths[i]);
+            const QString &filePath = info.conflictingFilePaths[i];
+
+            if (info.overwrittenFilePaths.contains(filePath)) {
+                tooltip += QString("• <span style='color: #f48771;'>%1 (overwritten)</span><br>")
+                    .arg(filePath);
+            } else {
+                tooltip += QString("• %1<br>").arg(filePath);
+            }
         }
         if (info.conflictingFilePaths.size() > 5) {
             tooltip += QString("• ... and %1 more<br>")


### PR DESCRIPTION
When merged this PR will:
- Color overwritten mod files in red in the mod conflict tooltip and modal
- Color modrow mod name in red when entire mod is overwritten