### PR TITLE
Launcher - Fix false flag virus detection by Windows defender

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
 project(TrenchKit
-  VERSION 1.1.4
+  VERSION 1.1.5
   LANGUAGES CXX
 )
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,11 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 #endif
 
 int main(int argc, char *argv[]) {
+#ifdef _WIN32
+    // Create named mutex to signal app is running (used by updater to wait for exit)
+    HANDLE hMutex = CreateMutexW(nullptr, FALSE, L"Global\\TrenchKitRunning");
+#endif
+
     QApplication app(argc, argv);
     QCoreApplication::setOrganizationName(QStringLiteral("TrenchKit"));
     QCoreApplication::setApplicationName(QStringLiteral("TrenchKit"));
@@ -40,6 +45,12 @@ int main(int argc, char *argv[]) {
     }
 
     int result = app.exec();
+
+#ifdef _WIN32
+    if (hMutex) {
+        CloseHandle(hMutex);
+    }
+#endif
 
     Logger::instance().shutdown();
     return result;


### PR DESCRIPTION
When merged this PR will:
- Add named mutex Global\TrenchKitRunning creation at startup
- Add mutex cleanup before exit
- Remove #include <tlhelp32.h> from updater (no longer needed)
- Replace isProcessRunning() + waitForProcessExit() with waitForAppExit() using mutex wait
- Close #61

_The updater no longer uses `CreateToolhelp32Snapshot` to enumerate all running processes (a technique commonly associated with malware). Instead, it simply waits for a named mutex that the main app holds while running._