### PR TITLE
Mod install - Add multi-URL support to Nexus and itch.io download modals

### DIFF
--- a/src/modals/mod_manager/AddModModalContent.cpp
+++ b/src/modals/mod_manager/AddModModalContent.cpp
@@ -217,58 +217,24 @@ void AddModModalContent::onFromNexusClicked() {
 
     auto *nexusModal = new NexusDownloadModalContent(m_nexusClient, m_nexusAuth, m_modalManager);
     connect(nexusModal, &NexusDownloadModalContent::accepted, this, [this, nexusModal]() {
-        QStringList filePaths = nexusModal->getDownloadedFilePaths();
-        if (filePaths.isEmpty()) {
+        QList<NexusDownloadResult> results = nexusModal->getDownloadResults();
+        if (results.isEmpty()) {
             return;
         }
 
-        QString nexusModId = nexusModal->getModId();
-        QString author = nexusModal->getAuthor();
-        QString description = nexusModal->getDescription();
-        QList<NexusFileInfo> files = nexusModal->getDownloadedFiles();
-
-        if (filePaths.size() > 1) {
-            QList<FileToProcess> filesToProcess;
-            for (int i = 0; i < filePaths.size(); ++i) {
-                FileToProcess fileData;
-                fileData.filePath = filePaths[i];
-                fileData.nexusModId = nexusModId;
-                fileData.author = author;
-                fileData.description = description;
-
-                if (i < files.size()) {
-                    fileData.nexusFileId = files[i].id;
-                    fileData.version = files[i].version;
-                }
-
-                filesToProcess.append(fileData);
-            }
-
-            startProcessingFiles(filesToProcess);
-        } else {
-            for (int i = 0; i < filePaths.size(); ++i) {
-                const QString &filePath = filePaths[i];
-
-                QString nexusFileId;
-                QString version;
-                if (i < files.size()) {
-                    nexusFileId = files[i].id;
-                    version = files[i].version;
-                }
-
-                if (isArchiveFile(filePath)) {
-                    handleArchiveFile(filePath, nexusModId, nexusFileId, author, description, version);
-                } else {
-                    handlePakFile(filePath, nexusModId, nexusFileId, author, description, version);
-                }
-
-                if (filePath.contains("nexus_mod_")) {
-                    QFile::remove(filePath);
-                }
-            }
-
-            accept();
+        QList<FileToProcess> filesToProcess;
+        for (const auto &result : results) {
+            FileToProcess fileData;
+            fileData.filePath = result.filePath;
+            fileData.nexusModId = result.modId;
+            fileData.nexusFileId = result.fileInfo.id;
+            fileData.author = result.author;
+            fileData.description = result.description;
+            fileData.version = result.fileInfo.version;
+            filesToProcess.append(fileData);
         }
+
+        startProcessingFiles(filesToProcess);
     });
     m_modalManager->showModal(nexusModal);
 }
@@ -280,48 +246,37 @@ void AddModModalContent::onFromItchClicked() {
 
     auto *itchModal = new ItchDownloadModalContent(m_itchClient, m_itchAuth, m_modalManager);
     connect(itchModal, &ItchDownloadModalContent::accepted, this, [this, itchModal]() {
-        QStringList filePaths = itchModal->getDownloadedFilePaths();
-        if (filePaths.isEmpty()) {
+        QList<ItchDownloadResult> results = itchModal->getDownloadResults();
+        if (results.isEmpty()) {
             return;
         }
 
-        QString itchGameId = itchModal->getGameId();
-        QString author = itchModal->getAuthor();
-        QString gameTitle = itchModal->getGameTitle();
-        QList<ItchUploadInfo> uploads = itchModal->getDownloadedUploads();
+        QList<FileToProcess> filesToProcess;
+        for (const auto &result : results) {
+            FileToProcess fileData;
+            fileData.filePath = result.filePath;
+            fileData.itchGameId = result.gameId;
+            fileData.author = result.author;
+            fileData.description = result.gameTitle;
 
-        for (int i = 0; i < filePaths.size(); ++i) {
-            const QString &filePath = filePaths[i];
-            QFileInfo fileInfo(filePath);
+            QDateTime uploadDate = result.uploadInfo.updatedAt.isValid()
+                ? result.uploadInfo.updatedAt : result.uploadInfo.createdAt;
+            fileData.uploadDate = uploadDate;
+
+            QFileInfo fileInfo(result.filePath);
             QString fileName = fileInfo.fileName();
-            QString modName;
-
             if (fileName.startsWith("itch_game_")) {
                 int secondUnderscore = fileName.indexOf('_', 10);
                 int thirdUnderscore = fileName.indexOf('_', secondUnderscore + 1);
                 if (thirdUnderscore != -1) {
-                    modName = fileName.mid(thirdUnderscore + 1);
-                    modName = QFileInfo(modName).baseName();
+                    fileData.customModName = QFileInfo(fileName.mid(thirdUnderscore + 1)).baseName();
                 }
             }
 
-            QDateTime uploadDate;
-            if (i < uploads.size()) {
-                uploadDate = uploads[i].updatedAt.isValid() ? uploads[i].updatedAt : uploads[i].createdAt;
-            }
-
-            if (isArchiveFile(filePath)) {
-                handleArchiveFile(filePath, "", "", author, gameTitle, "", itchGameId, uploadDate);
-            } else {
-                handlePakFile(filePath, "", "", author, gameTitle, "", itchGameId, modName, uploadDate);
-            }
-
-            if (filePath.contains("itch_game_")) {
-                QFile::remove(filePath);
-            }
+            filesToProcess.append(fileData);
         }
 
-        accept();
+        startProcessingFiles(filesToProcess);
     });
     m_modalManager->showModal(itchModal);
 }

--- a/src/modals/mod_manager/ItchDownloadModalContent.h
+++ b/src/modals/mod_manager/ItchDownloadModalContent.h
@@ -10,11 +10,20 @@
 class ItchClient;
 class ItchAuth;
 class ModalManager;
+class QPlainTextEdit;
 class QLineEdit;
 class QPushButton;
 class QProgressBar;
 class QLabel;
 class QStackedWidget;
+
+struct ItchDownloadResult {
+    QString filePath;
+    QString gameId;
+    QString gameTitle;
+    QString author;
+    ItchUploadInfo uploadInfo;
+};
 
 class ItchDownloadModalContent : public BaseModalContent {
     Q_OBJECT
@@ -31,6 +40,7 @@ public:
     QString getGameTitle() const { return m_gameTitle; }
     QString getAuthor() const { return m_author; }
     QList<ItchUploadInfo> getDownloadedUploads() const { return m_pendingUploads; }
+    QList<ItchDownloadResult> getDownloadResults() const { return m_results; }
 
 signals:
     void downloadComplete(QString filePath);
@@ -46,6 +56,11 @@ private slots:
     void onError(const QString &error);
 
 private:
+    struct PendingGame {
+        QString creator;
+        QString gameName;
+    };
+
     void setupUi();
     QWidget* createInputPage();
     QWidget* createAuthPage();
@@ -55,6 +70,7 @@ private:
     void showDownloadPage();
     void startDownloadProcess();
     void startNextDownload();
+    void startNextGame();
     QString generateTempPath(const QString &fileName) const;
     void updateFooterButtons();
     QString formatFileSize(qint64 bytes) const;
@@ -64,7 +80,7 @@ private:
     ModalManager *m_modalManager;
 
     QStackedWidget *m_stack;
-    QLineEdit *m_urlEdit;
+    QPlainTextEdit *m_urlEdit;
     QLineEdit *m_apiKeyEdit;
     QPushButton *m_downloadButton;
     QPushButton *m_submitApiKeyButton;
@@ -81,6 +97,10 @@ private:
     QString m_author;
     QString m_pendingCreator;
     QString m_pendingGameName;
+
+    QList<PendingGame> m_pendingGames;
+    int m_currentGameIndex = 0;
+    QList<ItchDownloadResult> m_results;
 
     QList<ItchUploadInfo> m_pendingUploads;
     int m_currentDownloadIndex = 0;

--- a/src/modals/mod_manager/NexusDownloadModalContent.h
+++ b/src/modals/mod_manager/NexusDownloadModalContent.h
@@ -9,11 +9,19 @@
 class NexusModsClient;
 class NexusModsAuth;
 class ModalManager;
-class QLineEdit;
+class QPlainTextEdit;
 class QPushButton;
 class QProgressBar;
 class QLabel;
 class QStackedWidget;
+
+struct NexusDownloadResult {
+    QString filePath;
+    QString modId;
+    NexusFileInfo fileInfo;
+    QString author;
+    QString description;
+};
 
 class NexusDownloadModalContent : public BaseModalContent {
     Q_OBJECT
@@ -29,6 +37,7 @@ public:
     QString getModId() const { return m_currentModId; }
     QString getAuthor() const { return m_author; }
     QString getDescription() const { return m_description; }
+    QList<NexusDownloadResult> getDownloadResults() const { return m_results; }
 
 private slots:
     void onDownloadClicked();
@@ -44,6 +53,11 @@ private slots:
     void onError(const QString &error);
 
 private:
+    struct PendingMod {
+        QString modId;
+        QString fileId;
+    };
+
     void setupUi();
     QWidget* createInputPage();
     QWidget* createAuthPage();
@@ -53,6 +67,7 @@ private:
     void showDownloadPage();
     void startDownloadProcess();
     void startNextDownload();
+    void startNextMod();
     void startManualDownloadSequence();
     QString generateTempPath(const QString &fileName) const;
     void updateFooterButtons();
@@ -63,7 +78,7 @@ private:
     ModalManager *m_modalManager;
 
     QStackedWidget *m_stack;
-    QLineEdit *m_urlEdit;
+    QPlainTextEdit *m_urlEdit;
     QPushButton *m_downloadButton;
     QPushButton *m_authenticateButton;
     QPushButton *m_cancelButton;
@@ -76,6 +91,10 @@ private:
     QStringList m_downloadedFilePaths;
     QList<NexusFileInfo> m_downloadedFiles;
     int m_currentDownloadIndex;
+
+    QList<PendingMod> m_pendingMods;
+    int m_currentModIndex = 0;
+    QList<NexusDownloadResult> m_results;
 
     QString m_currentModId;
     QString m_currentFileId;


### PR DESCRIPTION
When merged this PR will:
- Replace single-line URL input with multi-line text area allowing users to paste multiple mod URLs at once. Mods are processed sequentially through the existing API chain, with per-file result tracking for correct metadata association.
- Closes #58 