### PR TITLE
Mod installs - Add multi-select support for local file installs

### DIFF
--- a/src/core/managers/ModManager.cpp
+++ b/src/core/managers/ModManager.cpp
@@ -119,8 +119,13 @@ bool ModManager::addMod(const QString &pakFilePath, const AddModParams &params) 
     }
 
     QString destPath = m_modsStoragePath + "/" + mod.fileName;
-    if (!QFile::copy(pakFilePath, destPath)) {
-        emit errorOccurred(tr("Failed to copy mod file to storage"));
+    if (QFile::exists(destPath)) {
+        emit errorOccurred(tr("Mod already installed: \"%1\" is already in your mod library.").arg(mod.name));
+        return false;
+    }
+    QFile srcFile(pakFilePath);
+    if (!srcFile.copy(destPath)) {
+        emit errorOccurred(tr("Failed to copy mod file to storage: %1").arg(srcFile.errorString()));
         return false;
     }
 

--- a/src/modals/mod_manager/AddModModalContent.cpp
+++ b/src/modals/mod_manager/AddModModalContent.cpp
@@ -99,9 +99,9 @@ void AddModModalContent::retranslateUi() {
 }
 
 void AddModModalContent::onFromFileClicked() {
-    QString filePath = QFileDialog::getOpenFileName(
+    QStringList filePaths = QFileDialog::getOpenFileNames(
         this,
-        tr("Select Mod File"),
+        tr("Select Mod Files"),
         QString(),
         tr("Mod Files (*.pak *.zip *.rar *.7z *.tar.gz *.tar.bz2 *.tar.xz);;"
            "Pak Files (*.pak);;"
@@ -109,15 +109,18 @@ void AddModModalContent::onFromFileClicked() {
            "All Files (*.*)")
     );
 
-    if (filePath.isEmpty()) {
+    if (filePaths.isEmpty()) {
         return;
     }
 
-    if (isArchiveFile(filePath)) {
-        handleArchiveFile(filePath);
-    } else {
-        handlePakFile(filePath);
+    QList<FileToProcess> filesToProcess;
+    for (const QString &filePath : filePaths) {
+        FileToProcess fileData;
+        fileData.filePath = filePath;
+        filesToProcess.append(fileData);
     }
+
+    startProcessingFiles(filesToProcess);
 }
 
 bool AddModModalContent::isArchiveFile(const QString &filePath) const {


### PR DESCRIPTION
<!--
PR title format: area - verb changes
  Translations - Add French translation
  Mod list - Fix list not refreshing after import
  Installer - Improve path detection on Linux
  Settings - Remove deprecated update channel option

Verbs: Add, Fix, Improve, Change, Make, Remove
The title appears directly in the changelog, so keep it clear and concise.
-->

## What does this PR do?

Closes #79 
 
- Adds a pre-flight duplicate check in ModManager::addMod() — if a mod with the same filename already exists in storage, the user now sees "Mod already installed: "[name]" is already in your mod library." instead of a generic copy failure
- Switches from the static QFile::copy() to the instance form so the OS error string is included in any other copy failure (e.g. permission denied, disk full)
- Adds multi-select support to the "From File" dialog — users can now select multiple pak/archive files at once and they are processed sequentially with a progress indicator

## How was it tested?

- Attempted to install a mod that was already in the library — confirmed the specific "already installed" error appears
- Attempted to install a mod normally — confirmed no regression

## Checklist

- [X] I have read and understood the [contribution guidelines](https://github.com/Tapawingo/TrenchKit/blob/main/CONTRIBUTING.md)
- [X] PR title follows the format: `area - Add|Fix|Improve|Change|Make|Remove {changes}`
