### PR TITLE
Linux - Add Linux AppImage and zip packaging with full platform support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ GENERATOR=Ninja
 PACKAGE_RELEASE_ARGS=
 BUILD_LINUX_ARGS=
 
+ifeq ($(OS),Windows_NT)
+EXE_EXT = .exe
+else
+EXE_EXT =
+endif
+
 .PHONY: all configure-debug configure-release build-debug build-release package-release package-release-no-installer package-release-require-installer package-linux-release test test-debug run-debug run-release translations-template clean
 
 all: build-debug
@@ -42,10 +48,10 @@ test-debug: build-debug
 	ctest --test-dir $(BUILD_DIR_DEBUG) --output-on-failure
 
 run-debug: build-debug
-	$(BUILD_DIR_DEBUG)/TrenchKit.exe
+	$(BUILD_DIR_DEBUG)/TrenchKit$(EXE_EXT)
 
 run-release: build-release
-	$(BUILD_DIR_RELEASE)/TrenchKit.exe
+	$(BUILD_DIR_RELEASE)/TrenchKit$(EXE_EXT)
 
 translations-template: configure-debug
 	cmake --build $(BUILD_DIR_DEBUG) --target update_translation_template

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,4 +1,4 @@
 set(TRENCHKIT_VERSION_MAJOR 1)
 set(TRENCHKIT_VERSION_MINOR 3)
-set(TRENCHKIT_VERSION_PATCH 0)
-set(TRENCHKIT_VERSION_PRERELEASE "")  # e.g. "alpha", "rc.1", "beta.2" — leave empty for stable releases
+set(TRENCHKIT_VERSION_PATCH 1)
+set(TRENCHKIT_VERSION_PRERELEASE "alpha")  # e.g. "alpha", "rc.1", "beta.2" — leave empty for stable releases

--- a/extras/linux/io.github.tapawingo.trenchkit.desktop
+++ b/extras/linux/io.github.tapawingo.trenchkit.desktop
@@ -5,3 +5,4 @@ Exec=TrenchKit
 Icon=io.github.tapawingo.trenchkit
 Categories=Game;Utility;
 Comment=Foxhole mod manager
+Terminal=false

--- a/extras/linux/io.github.tapawingo.trenchkit.desktop
+++ b/extras/linux/io.github.tapawingo.trenchkit.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=TrenchKit
+Exec=TrenchKit
+Icon=io.github.tapawingo.trenchkit
+Categories=Game;Utility;
+Comment=Foxhole mod manager

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -18,6 +18,7 @@
 #include <QSettings>
 #include <QShowEvent>
 #include <QPaintEvent>
+#include <QMouseEvent>
 #include <QPainter>
 #include <QPixmap>
 #include <QEvent>
@@ -38,6 +39,8 @@
 #ifdef Q_OS_WIN
 #include <windows.h>
 #include <windowsx.h>
+#else
+#include <QWindow>
 #endif
 
 namespace {
@@ -138,6 +141,9 @@ MainWindow::MainWindow(QWidget *parent)
 
     setMinimumSize(800, 560);
     resize(1000, 700);
+#ifndef Q_OS_WIN
+    setMouseTracking(true);
+#endif
 
     // Add initial log entry
     ActivityLogWidget * const log = m_rightPanelWidget->getActivityLog();
@@ -221,6 +227,42 @@ void MainWindow::onMaximizeClicked() {
         showMaximized();
     }
 }
+
+#ifndef Q_OS_WIN
+static Qt::Edges resizeEdges(const QPoint &pos, const QRect &r, int b) {
+    Qt::Edges e;
+    if (pos.x() < b)               e |= Qt::LeftEdge;
+    if (pos.x() > r.width()  - b)  e |= Qt::RightEdge;
+    if (pos.y() < b)               e |= Qt::TopEdge;
+    if (pos.y() > r.height() - b)  e |= Qt::BottomEdge;
+    return e;
+}
+
+void MainWindow::mousePressEvent(QMouseEvent *event) {
+    if (event->button() == Qt::LeftButton && !isMaximized()) {
+        const Qt::Edges edges = resizeEdges(event->pos(), rect(), 8);
+        if (edges && windowHandle()) {
+            windowHandle()->startSystemResize(edges);
+            return;
+        }
+    }
+    QMainWindow::mousePressEvent(event);
+}
+
+void MainWindow::mouseMoveEvent(QMouseEvent *event) {
+    if (!isMaximized()) {
+        const Qt::Edges e = resizeEdges(event->pos(), rect(), 8);
+        if      ((e & Qt::LeftEdge  && e & Qt::TopEdge)    ||
+                 (e & Qt::RightEdge && e & Qt::BottomEdge)) setCursor(Qt::SizeFDiagCursor);
+        else if ((e & Qt::RightEdge && e & Qt::TopEdge)    ||
+                 (e & Qt::LeftEdge  && e & Qt::BottomEdge)) setCursor(Qt::SizeBDiagCursor);
+        else if (e & (Qt::LeftEdge | Qt::RightEdge))        setCursor(Qt::SizeHorCursor);
+        else if (e & (Qt::TopEdge  | Qt::BottomEdge))       setCursor(Qt::SizeVerCursor);
+        else                                                 unsetCursor();
+    }
+    QMainWindow::mouseMoveEvent(event);
+}
+#endif
 
 bool MainWindow::nativeEvent(const QByteArray &eventType, void *message, qintptr *result) {
 #ifdef Q_OS_WIN

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -673,6 +673,14 @@ void MainWindow::onUpdateDownloadFinished(const QString &savePath) {
         }
     }
 
+#ifdef Q_OS_LINUX
+    if (!qEnvironmentVariable("APPIMAGE").isEmpty()) {
+        // AppImage mode: the downloaded file IS the update — no extraction needed
+        launchUpdater(savePath, updatesDir);
+        return;
+    }
+#endif
+
     QString error;
     if (!stageUpdate(savePath, version, updatesDir, &error)) {
         MessageModal::warning(m_modalManager, tr("Update Error"), error);
@@ -750,15 +758,6 @@ void MainWindow::closeUpdateDialog() {
 }
 
 QString MainWindow::selectUpdateAssetName() const {
-    QString platform;
-#if defined(Q_OS_WIN)
-    platform = "windows";
-#elif defined(Q_OS_LINUX)
-    platform = "linux";
-#else
-    return QString();
-#endif
-
     QString version = m_updateRelease.version.toString();
     if (version.isEmpty()) {
         version = m_updateRelease.tagName;
@@ -771,7 +770,15 @@ QString MainWindow::selectUpdateAssetName() const {
         return QString();
     }
 
-    return QString("%1-%2.zip").arg(platform, version);
+#if defined(Q_OS_WIN)
+    return QStringLiteral("windows-%1.zip").arg(version);
+#elif defined(Q_OS_LINUX)
+    if (!qEnvironmentVariable("APPIMAGE").isEmpty())
+        return QStringLiteral("TrenchKit-%1-x86_64.AppImage").arg(version);
+    return QStringLiteral("linux-%1.zip").arg(version);
+#else
+    return QString();
+#endif
 }
 
 bool MainWindow::stageUpdate(const QString &archivePath,
@@ -806,6 +813,42 @@ bool MainWindow::stageUpdate(const QString &archivePath,
 }
 
 void MainWindow::launchUpdater(const QString &stagingDir, const QString &updatesDir) {
+#ifdef Q_OS_LINUX
+    const QString appImagePath = qEnvironmentVariable("APPIMAGE");
+    if (!appImagePath.isEmpty()) {
+        // AppImage mode: copy the updater out of the AppImage mount before quitting,
+        // because the mount point disappears once the process exits.
+        const QString appDir = qEnvironmentVariable("APPDIR");
+        const QString updaterSrc = QDir(appDir).filePath("usr/bin/TrenchKitUpdater");
+        const QString tmpUpdater = QDir::tempPath() + QStringLiteral("/TrenchKitUpdater_update");
+        QFile::remove(tmpUpdater);
+        if (!QFile::copy(updaterSrc, tmpUpdater)) {
+            MessageModal::warning(m_modalManager, tr("Update Error"),
+                                  tr("Failed to stage updater helper."));
+            return;
+        }
+        QFile::setPermissions(tmpUpdater,
+            QFileDevice::ExeOwner | QFileDevice::ReadOwner | QFileDevice::WriteOwner);
+
+        QStringList args;
+        args << "--install"
+             << "--appimage-path" << appImagePath
+             << "--new-file"      << stagingDir   // stagingDir holds new AppImage path in this mode
+             << "--updates-dir"   << updatesDir
+             << "--pid"           << QString::number(QCoreApplication::applicationPid());
+
+        qInfo() << "Updater: launching AppImage helper" << tmpUpdater;
+        qint64 pid = 0;
+        if (!QProcess::startDetached(tmpUpdater, args, QDir::tempPath(), &pid)) {
+            MessageModal::warning(m_modalManager, tr("Update Error"),
+                                  tr("Failed to launch updater helper."));
+            return;
+        }
+        QCoreApplication::quit();
+        return;
+    }
+#endif
+
     const QString appDir = QCoreApplication::applicationDirPath();
     const QString exeName = QFileInfo(QCoreApplication::applicationFilePath()).fileName();
 
@@ -822,10 +865,11 @@ void MainWindow::launchUpdater(const QString &stagingDir, const QString &updates
 
     QStringList args;
     args << "--install"
-         << "--app-dir" << appDir
-         << "--new-dir" << stagingDir
+         << "--app-dir"    << appDir
+         << "--new-dir"    << stagingDir
          << "--updates-dir" << updatesDir
-         << "--exe-name" << exeName;
+         << "--exe-name"   << exeName
+         << "--pid"        << QString::number(QCoreApplication::applicationPid());
 
     qInfo() << "Updater: launching helper" << updaterExe;
     qint64 pid = 0;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -57,6 +57,10 @@ protected:
     void changeEvent(QEvent *event) override;
     bool eventFilter(QObject *watched, QEvent *event) override;
     bool nativeEvent(const QByteArray &eventType, void *message, qintptr *result) override;
+#ifndef Q_OS_WIN
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+#endif
 
 private slots:
     void onMinimizeClicked();

--- a/src/common/widgets/TitleBar.cpp
+++ b/src/common/widgets/TitleBar.cpp
@@ -118,6 +118,10 @@ void TitleBar::mousePressEvent(QMouseEvent *event) {
         m_dragging = true;
         m_dragPosition = event->globalPosition().toPoint() - window()->frameGeometry().topLeft();
         event->accept();
+        if (!window()->isMaximized() && window()->windowHandle()) {
+            if (window()->windowHandle()->startSystemMove())
+                m_dragging = false;
+        }
     }
 }
 
@@ -129,6 +133,11 @@ void TitleBar::mouseMoveEvent(QMouseEvent *event) {
             window()->showNormal();
             m_dragPosition = QPoint(static_cast<int>(window()->width() * relX),
                                     m_dragPosition.y());
+            if (window()->windowHandle() && window()->windowHandle()->startSystemMove()) {
+                m_dragging = false;
+                event->accept();
+                return;
+            }
         }
         window()->move(event->globalPosition().toPoint() - m_dragPosition);
         event->accept();

--- a/src/core/managers/ModManager.cpp
+++ b/src/core/managers/ModManager.cpp
@@ -722,6 +722,12 @@ bool ModManager::copyModToPaks(const ModInfo &mod) {
         return false;
     }
 
+#ifdef Q_OS_LINUX
+    QFile::setPermissions(destPath,
+        QFileDevice::ReadOwner | QFileDevice::WriteOwner |
+        QFileDevice::ReadGroup | QFileDevice::ReadOther);
+#endif
+
     {
         QMutexLocker locker(&m_modsMutex);
         auto it = std::ranges::find_if(m_mods,
@@ -827,6 +833,11 @@ void ModManager::renumberEnabledMods() {
         if (mod.numberedFileName == newNumberedName) {
             if (!QFile::exists(expectedPath) && QFile::exists(sourcePath)) {
                 QFile::copy(sourcePath, expectedPath);
+#ifdef Q_OS_LINUX
+                QFile::setPermissions(expectedPath,
+                    QFileDevice::ReadOwner | QFileDevice::WriteOwner |
+                    QFileDevice::ReadGroup | QFileDevice::ReadOther);
+#endif
                 QMutexLocker locker(&m_modsMutex);
                 auto it = std::ranges::find_if(m_mods,
                                        [&mod](const ModInfo &item) { return item.id == mod.id; });
@@ -854,6 +865,11 @@ void ModManager::renumberEnabledMods() {
 
         if (QFile::exists(sourcePath)) {
             QFile::copy(sourcePath, expectedPath);
+#ifdef Q_OS_LINUX
+            QFile::setPermissions(expectedPath,
+                QFileDevice::ReadOwner | QFileDevice::WriteOwner |
+                QFileDevice::ReadGroup | QFileDevice::ReadOther);
+#endif
             QMutexLocker locker(&m_modsMutex);
             auto it = std::ranges::find_if(m_mods,
                                    [&mod](const ModInfo &item) { return item.id == mod.id; });

--- a/src/core/utils/ArchiveExtractor.cpp
+++ b/src/core/utils/ArchiveExtractor.cpp
@@ -167,7 +167,7 @@ ArchiveExtractor::ExtractResult ArchiveExtractor::extractWithLibarchive(
             continue;
         }
 
-        QString fileName = QString::fromUtf8(entryName);
+        QString fileName = QString::fromUtf8(entryName).replace(u'\\', u'/');
         entryCount++;
         qDebug() << "ArchiveExtractor: Entry" << entryCount << ":" << fileName;
 
@@ -274,7 +274,7 @@ ArchiveExtractor::ExtractResult ArchiveExtractor::extractWithZip(const QString &
         }
 
         const char *entryName = zip_entry_name(zip);
-        QString fileName = QString::fromUtf8(entryName);
+        QString fileName = QString::fromUtf8(entryName).replace(u'\\', u'/');
 
         if (isPakFile(fileName)) {
             QString baseName = QFileInfo(fileName).fileName();

--- a/src/core/utils/FoxholeDetector.cpp
+++ b/src/core/utils/FoxholeDetector.cpp
@@ -49,7 +49,8 @@ QString FoxholeDetector::detectInstallPath() {
         }
     }
 
-    // Check common installation paths
+#ifdef Q_OS_WIN
+    // Check common installation paths (Windows drive letters only)
     QStringList commonPaths = {
         "C:/Program Files (x86)/Steam/steamapps/common/Foxhole",
         "C:/Program Files/Steam/steamapps/common/Foxhole",
@@ -69,6 +70,7 @@ QString FoxholeDetector::detectInstallPath() {
             return foxholePath;
         }
     }
+#endif
 
     qDebug() << "Foxhole installation not found";
     return QString(); // Not found
@@ -141,14 +143,14 @@ QString FoxholeDetector::checkPath(const QString &basePath) {
 
     qDebug() << "  Checking path:" << dir.absolutePath();
 
-    // List of possible Foxhole executables to check
+#ifdef Q_OS_WIN
+    // Check for Windows executables
     QStringList possibleExes = {
         "Foxhole.exe",
         "FoxholeClient.exe",
         "FoxholeClient-Win64-Shipping.exe"
     };
 
-    // Check for executable in root directory
     for (const QString &exe : possibleExes) {
         QString exePath = dir.filePath(exe);
         if (QFile::exists(exePath)) {
@@ -157,7 +159,6 @@ QString FoxholeDetector::checkPath(const QString &basePath) {
         }
     }
 
-    // Check for Foxhole executable in War/Binaries/Win64/ subdirectory
     QDir warDir = dir;
     if (warDir.cd("War") && warDir.cd("Binaries") && warDir.cd("Win64")) {
         qDebug() << "    Checking War/Binaries/Win64/";
@@ -169,6 +170,7 @@ QString FoxholeDetector::checkPath(const QString &basePath) {
             }
         }
     }
+#endif
 
     // Also check for other Foxhole-specific files/folders
     QStringList indicators = {

--- a/src/core/utils/UpdateArchiveExtractor.cpp
+++ b/src/core/utils/UpdateArchiveExtractor.cpp
@@ -62,8 +62,13 @@ bool UpdateArchiveExtractor::extractWithLibarchive(const QString &archivePath,
             continue;
         }
 
-        const QString entryPath = QString::fromUtf8(entryName);
-        const QString outputPath = QDir(destDir).filePath(entryPath);
+        const QString entryPath = QString::fromUtf8(entryName).replace(u'\\', u'/');
+        const QString cleanPath = QDir::cleanPath(entryPath);
+        if (cleanPath.startsWith(QLatin1String("..")) || QDir::isAbsolutePath(cleanPath)) {
+            archive_read_data_skip(a);
+            continue;
+        }
+        const QString outputPath = QDir(destDir).filePath(cleanPath);
 
         if (archive_entry_filetype(entry) == AE_IFDIR) {
             dir.mkpath(outputPath);
@@ -174,8 +179,13 @@ bool UpdateArchiveExtractor::extractWithZip(const QString &zipPath,
             continue;
         }
 
-        const QString entryPath = QString::fromUtf8(entryName);
-        const QString outputPath = QDir(destDir).filePath(entryPath);
+        const QString entryPath = QString::fromUtf8(entryName).replace(u'\\', u'/');
+        const QString cleanPath = QDir::cleanPath(entryPath);
+        if (cleanPath.startsWith(QLatin1String("..")) || QDir::isAbsolutePath(cleanPath)) {
+            zip_entry_close(zip);
+            continue;
+        }
+        const QString outputPath = QDir(destDir).filePath(cleanPath);
 
         if (zip_entry_isdir(zip)) {
             dir.mkpath(outputPath);

--- a/src/modals/mod_manager/ConflictDetailModalContent.cpp
+++ b/src/modals/mod_manager/ConflictDetailModalContent.cpp
@@ -55,7 +55,7 @@ void ConflictDetailModalContent::setupUi() {
         "    color: %1;"
         "    border: 1px solid #404040;"
         "    font-size: 12px;"
-        "    font-family: 'Consolas', 'Courier New', monospace;"
+        "    font-family: 'Consolas', 'DejaVu Sans Mono', 'Liberation Mono', 'Courier New', monospace;"
         "}"
         "QListWidget::item {"
         "    padding: 4px;"

--- a/src/views/mod_manager/InstallPathWidget.cpp
+++ b/src/views/mod_manager/InstallPathWidget.cpp
@@ -166,21 +166,20 @@ bool InstallPathWidget::checkFoxholeInstallation(const QString &path) const {
         return false;
     }
 
-    // List of possible Foxhole executables
+#ifdef Q_OS_WIN
+    // Check for Windows executables
     QStringList possibleExes = {
         "Foxhole.exe",
         "FoxholeClient.exe",
         "FoxholeClient-Win64-Shipping.exe"
     };
 
-    // Check for executable in root directory
     for (const QString &exe : possibleExes) {
         if (QFile::exists(dir.filePath(exe))) {
             return true;
         }
     }
 
-    // Check for Foxhole executable in War/Binaries/Win64/
     QDir warDir = dir;
     if (warDir.cd("War") && warDir.cd("Binaries") && warDir.cd("Win64")) {
         for (const QString &exe : possibleExes) {
@@ -189,6 +188,7 @@ bool InstallPathWidget::checkFoxholeInstallation(const QString &path) const {
             }
         }
     }
+#endif
 
     // Check for other Foxhole-specific directories
     if (QDir(dir.filePath("War/Content/Paks")).exists() ||

--- a/src/views/mod_manager/LaunchWidget.cpp
+++ b/src/views/mod_manager/LaunchWidget.cpp
@@ -8,9 +8,15 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QProcess>
+#include <QDesktopServices>
+#include <QUrl>
 #include <QDir>
 #include <QFile>
 #include <QTimer>
+
+#ifdef Q_OS_LINUX
+static constexpr int FOXHOLE_STEAM_APP_ID = 1454690;
+#endif
 
 LaunchWidget::LaunchWidget(QWidget *parent)
     : QWidget(parent)
@@ -99,6 +105,15 @@ void LaunchWidget::setupConnections() {
 }
 
 void LaunchWidget::onLaunchWithMods() {
+#ifdef Q_OS_LINUX
+    if (m_foxholeInstallPath.isEmpty()) {
+        emit errorOccurred(tr("Foxhole installation not found. Please check your installation path."));
+        return;
+    }
+    QDesktopServices::openUrl(QUrl(QStringLiteral("steam://run/%1").arg(FOXHOLE_STEAM_APP_ID)));
+    emit gameLaunched(true);
+    return;
+#endif
     QString exePath = getFoxholeExecutablePath();
 
     if (exePath.isEmpty()) {
@@ -143,6 +158,11 @@ void LaunchWidget::onLaunchWithoutMods() {
             }
         }
 
+#ifdef Q_OS_LINUX
+        QDesktopServices::openUrl(QUrl(QStringLiteral("steam://run/%1").arg(FOXHOLE_STEAM_APP_ID)));
+        m_launchTimer.start();
+        emit gameLaunched(false);
+#else
         if (m_gameProcess) {
             m_gameProcess->deleteLater();
         }
@@ -169,6 +189,7 @@ void LaunchWidget::onLaunchWithoutMods() {
             m_waitingForGameExit = false;
             emit gameLaunched(false);
         }
+#endif
 
         if (!m_modsToRestore.isEmpty()) {
             m_waitingForGameStart = true;
@@ -359,8 +380,16 @@ bool LaunchWidget::isGameRunning() const {
     }
     return false;
 #else
-    if (m_gameProcess) {
-        return m_gameProcess->state() != QProcess::NotRunning;
+    const QStringList procNames = {
+        QStringLiteral("FoxholeClient-Win64-Shipping"),
+        QStringLiteral("War-Win64-Shipping"),
+        QStringLiteral("FoxholeClient"),
+    };
+    for (const QString &name : procNames) {
+        QProcess pgrep;
+        pgrep.start(QStringLiteral("pgrep"), QStringList() << QStringLiteral("-f") << name);
+        if (pgrep.waitForFinished(1000) && pgrep.exitCode() == 0)
+            return true;
     }
     return false;
 #endif

--- a/src/views/settings/SettingsWidget.cpp
+++ b/src/views/settings/SettingsWidget.cpp
@@ -75,7 +75,11 @@ void SettingsWidget::retranslateUi() {
     }
     if (m_autoCheckLabel) m_autoCheckLabel->setText(tr("Check for updates on startup"));
     if (m_downloadLabel) m_downloadLabel->setText(tr("Download location (optional)"));
-    if (m_downloadDirEdit) m_downloadDirEdit->setPlaceholderText(tr("Default: AppData/Local/TrenchKit/updates"));
+    if (m_downloadDirEdit) m_downloadDirEdit->setPlaceholderText(
+        tr("Default: %1").arg(
+            QDir::toNativeSeparators(
+                QDir(QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation))
+                    .filePath(QStringLiteral("updates")))));
     if (m_downloadBrowseButton) m_downloadBrowseButton->setText(tr("Browse..."));
     if (m_checkLabel) m_checkLabel->setText(tr("Check for updates now"));
     if (m_checkNowButton) m_checkNowButton->setText(tr("Check now"));
@@ -835,7 +839,8 @@ bool SettingsWidget::createShortcut(const QString &shortcutPath, const QString &
         QStringLiteral("[Desktop Entry]\nVersion=1.0\nType=Application\n"
                        "Name=TrenchKit\nComment=") + description +
         QStringLiteral("\nExec=\"") + targetPath +
-        QStringLiteral("\"\nTerminal=false\nCategories=Game;\n");
+        QStringLiteral("\"\nIcon=io.github.tapawingo.trenchkit\n"
+                       "Terminal=false\nCategories=Game;\n");
     QFile f(shortcutPath);
     if (!f.open(QIODevice::WriteOnly | QIODevice::Text))
         return false;
@@ -881,7 +886,10 @@ void SettingsWidget::onAddDesktopShortcutClicked() {
     const QString desktopPath =
         QStandardPaths::writableLocation(QStandardPaths::DesktopLocation)
         + QStringLiteral("/TrenchKit.desktop");
-    const QString exePath = QCoreApplication::applicationFilePath();
+    const QString appImagePath0 = qEnvironmentVariable("APPIMAGE");
+    const QString exePath = appImagePath0.isEmpty()
+        ? QCoreApplication::applicationFilePath()
+        : appImagePath0;
     if (QFile::exists(desktopPath)) {
         if (m_modalManager)
             MessageModal::information(m_modalManager, tr("Shortcut Already Exists"),
@@ -938,7 +946,10 @@ void SettingsWidget::onAddStartMenuShortcutClicked() {
         QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
     QDir().mkpath(appsPath);
     const QString shortcutPath = appsPath + QStringLiteral("/TrenchKit.desktop");
-    const QString exePath = QCoreApplication::applicationFilePath();
+    const QString appImagePath1 = qEnvironmentVariable("APPIMAGE");
+    const QString exePath = appImagePath1.isEmpty()
+        ? QCoreApplication::applicationFilePath()
+        : appImagePath1;
     if (QFile::exists(shortcutPath)) {
         if (m_modalManager)
             MessageModal::information(m_modalManager, tr("Shortcut Already Exists"),
@@ -994,7 +1005,8 @@ bool SettingsWidget::isTkprofileAssociationSet() const {
     return progId == QStringLiteral("TrenchKit.Profile");
 #elif defined(Q_OS_LINUX)
     return QFileInfo(
-        QDir::homePath() + "/.local/share/mime/packages/application-x-tkprofile.xml"
+        QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+        + "/mime/packages/application-x-tkprofile.xml"
     ).exists();
 #else
     return false;
@@ -1029,7 +1041,9 @@ bool SettingsWidget::registerTkprofileAssociation() {
     return classes.status() == QSettings::NoError;
 #elif defined(Q_OS_LINUX)
     // 1. Write MIME type XML
-    const QString mimeDir = QDir::homePath() + "/.local/share/mime/packages";
+    const QString mimeDir =
+        QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+        + "/mime/packages";
     if (!QDir().mkpath(mimeDir))
         return false;
     const QString mimeXml = mimeDir + "/application-x-tkprofile.xml";
@@ -1045,19 +1059,24 @@ bool SettingsWidget::registerTkprofileAssociation() {
             "</mime-info>\n");
     f.close();
     QProcess::execute(QStringLiteral("update-mime-database"),
-                      { QDir::homePath() + "/.local/share/mime" });
+                      { QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+                        + "/mime" });
 
     // 2. Create/update .desktop file with MimeType
     const QString appsDir =
         QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
     QDir().mkpath(appsDir);
     const QString desktopPath = appsDir + "/TrenchKit.desktop";
-    const QString exePath = QDir::toNativeSeparators(QCoreApplication::applicationFilePath());
+    const QString appImagePath = qEnvironmentVariable("APPIMAGE");
+    const QString exePath = appImagePath.isEmpty()
+        ? QCoreApplication::applicationFilePath()
+        : appImagePath;
     const QString desktop =
         QStringLiteral("[Desktop Entry]\nVersion=1.0\nType=Application\n"
                        "Name=TrenchKit\n"
                        "Comment=TrenchKit - Foxhole Mod Manager\n"
                        "Exec=\"") + exePath + QStringLiteral("\" \"%f\"\n"
+                       "Icon=io.github.tapawingo.trenchkit\n"
                        "Terminal=false\nCategories=Game;\n"
                        "MimeType=application/x-tkprofile;\n");
     QFile df(desktopPath);

--- a/tools/Dockerfile.linux-builder
+++ b/tools/Dockerfile.linux-builder
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libglib2.0-0 \
     libfontconfig1-dev libfreetype6-dev libdbus-1-dev \
     libxcb-cursor0 libxkbcommon-x11-0 \
+    wget file \
     zip \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tools/Dockerfile.linux-builder
+++ b/tools/Dockerfile.linux-builder
@@ -8,8 +8,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libglib2.0-0 \
     libfontconfig1-dev libfreetype6-dev libdbus-1-dev \
     libxcb-cursor0 libxkbcommon-x11-0 \
-    wget file \
-    zip \
+    libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+    libxcb-randr0 libxcb-render-util0 libxcb-shape0 \
+    libxcb-xinerama0 libxcb-xfixes0 libxcb-sync1 libxcb-util1 \
+    wget file patchelf \
+    zip imagemagick \
+    libbz2-dev liblzma-dev liblz4-dev libzstd-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # cmake from pip: apt on Ubuntu 22.04 ships 3.22, project requires 3.24+

--- a/tools/build_linux.py
+++ b/tools/build_linux.py
@@ -1,14 +1,15 @@
 """
-Build a self-contained Linux release binary using Docker and package it into dist/.
+Build a self-contained Linux AppImage using Docker and package it into dist/.
 
 Usage:
     python tools/build_linux.py [--qt-version 6.10.1] [--no-cache] [--reinstall-qt]
 
 Output:
-    dist/linux-{version}.zip
+    dist/TrenchKit-{version}-x86_64.AppImage
 
-Qt is installed once into a named Docker volume (trenchkit-qt-<version>) so
-subsequent builds are fast. Pass --reinstall-qt to force a fresh Qt install.
+Qt and AppImage tools (linuxdeploy, appimagetool) are cached in a named Docker
+volume (trenchkit-qt-<version>) so subsequent builds are fast. Pass --reinstall-qt
+to force a fresh Qt install (also re-downloads AppImage tools).
 
 Requires Docker to be installed and running.
 """
@@ -58,12 +59,36 @@ def qt_install_script(qt_version: str, qt_dir: str) -> str:
     """)
 
 
-def build_package_script(qt_dir: str, archive_name: str) -> str:
-    """Configures, builds, and packages TrenchKit inside the container."""
+def tools_install_script() -> str:
+    """Downloads linuxdeploy, linuxdeploy-plugin-qt, and appimagetool into /qt/tools/."""
+    return textwrap.dedent("""\
+        set -e
+        TOOLS=/qt/tools
+        mkdir -p "$TOOLS"
+        dl() {
+            local name="$1" url="$2"
+            if [ ! -f "$TOOLS/$name" ]; then
+                echo "==> Downloading $name..."
+                wget -q --show-progress -O "$TOOLS/$name" "$url"
+                chmod +x "$TOOLS/$name"
+            else
+                echo "==> $name already cached, skipping."
+            fi
+        }
+        dl linuxdeploy           https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+        dl linuxdeploy-plugin-qt https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+        dl appimagetool          https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+        echo "==> AppImage tools ready."
+    """)
+
+
+def build_package_script(qt_dir: str, version: str, archive_name: str) -> str:
+    """Configures, builds, and packages TrenchKit as an AppImage inside the container."""
     return textwrap.dedent(f"""\
         set -e
         export PATH="{qt_dir}/bin:$PATH"
         export CMAKE_PREFIX_PATH="{qt_dir}"
+        export APPIMAGE_EXTRACT_AND_RUN=1
 
         echo "==> Configuring..."
         cmake -S /src -B /build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5
@@ -71,74 +96,42 @@ def build_package_script(qt_dir: str, archive_name: str) -> str:
         echo "==> Building..."
         cmake --build /build
 
-        echo "==> Packaging..."
-        STAGE=/tmp/stage
-        rm -rf "$STAGE"
-        mkdir -p "$STAGE/lib" "$STAGE/platforms" "$STAGE/tls"
+        echo "==> Staging AppDir..."
+        APPDIR=/tmp/AppDir
+        rm -rf "$APPDIR"
+        mkdir -p "$APPDIR/usr/bin" \\
+                 "$APPDIR/usr/share/applications" \\
+                 "$APPDIR/usr/share/icons/hicolor/256x256/apps"
 
-        # Binaries
-        cp /build/src/TrenchKit    "$STAGE/"
-        cp /build/updater/TrenchKitUpdater  "$STAGE/"
+        cp /build/src/TrenchKit            "$APPDIR/usr/bin/"
+        cp /build/updater/TrenchKitUpdater "$APPDIR/usr/bin/"
 
-        # TLS plugin
+        cp /src/extras/linux/io.github.tapawingo.trenchkit.desktop \\
+           "$APPDIR/usr/share/applications/"
+        cp /src/extras/logo/logo_transparent.png \\
+           "$APPDIR/usr/share/icons/hicolor/256x256/apps/io.github.tapawingo.trenchkit.png"
+
+        # TLS plugin — place it where Qt expects it inside the AppDir
         TLS_SRC=/build/src/tls/libqopensslbackend.so
-        [ -f "$TLS_SRC" ] && cp "$TLS_SRC" "$STAGE/tls/"
-
-        # xcb platform plugin (keep XCB_SRC for the ldd sweep below)
-        XCB_SRC="{qt_dir}/plugins/platforms/libqxcb.so"
-        [ -f "$XCB_SRC" ] && cp "$XCB_SRC" "$STAGE/platforms/"
-
-        # Qt shared libraries needed by the binary and plugins
-        QT_LIB_DIR="{qt_dir}/lib"
-        for lib in \\
-            libQt6Core libQt6Gui libQt6Widgets \\
-            libQt6Network libQt6Concurrent libQt6WebSockets \\
-            libQt6XcbQpa libQt6DBus libQt6OpenGL
-        do
-            src=$(find "$QT_LIB_DIR" -maxdepth 1 -name "${{lib}}.so.*" ! -name "*.debug" | sort | tail -1)
-            [ -n "$src" ] && cp "$src" "$STAGE/lib/"
-        done
-
-        # Sweep all Qt source libs for any deps Qt bundles in its own dir
-        # (covers ICU 73, libzstd, and anything else Qt ships alongside its modules)
-        for qt_src in "$QT_LIB_DIR"/libQt6*.so.*; do
-            [ -f "$qt_src" ] || continue
-            ldd "$qt_src" 2>/dev/null | awk '/=> \\// {{print $3}}' | while read -r dep; do
-                [[ "$dep" == /qt/* ]] || continue
-                base=$(basename "$dep")
-                [ -f "$dep" ] && [ ! -f "$STAGE/lib/$base" ] && cp "$dep" "$STAGE/lib/"
-            done
-        done
-        # Same sweep for the xcb plugin
-        if [ -f "$STAGE/platforms/libqxcb.so" ]; then
-            ldd "$XCB_SRC" 2>/dev/null | awk '/=> \\// {{print $3}}' | while read -r dep; do
-                [[ "$dep" == /qt/* ]] || continue
-                base=$(basename "$dep")
-                [ -f "$dep" ] && [ ! -f "$STAGE/lib/$base" ] && cp "$dep" "$STAGE/lib/"
-            done
+        if [ -f "$TLS_SRC" ]; then
+            mkdir -p "$APPDIR/usr/plugins/tls"
+            cp "$TLS_SRC" "$APPDIR/usr/plugins/tls/"
         fi
 
-        # Create SONAME symlinks (e.g. libQt6Core.so.6 -> libQt6Core.so.6.10.1)
-        # Without these the ELF loader cannot find the bundled libs and falls back to system Qt
-        for f in "$STAGE/lib/"*.so.*; do
-            [ -L "$f" ] && continue
-            soname=$(readelf -d "$f" 2>/dev/null | awk '/SONAME/ {{gsub(/[\\[\\]]/, "", $NF); print $NF}}')
-            [ -n "$soname" ] && [ ! -e "$STAGE/lib/$soname" ] && ln -sf "$(basename "$f")" "$STAGE/lib/$soname"
-        done
+        echo "==> Running linuxdeploy with Qt plugin..."
+        export QMAKE="{qt_dir}/bin/qmake"
+        # Run the Qt plugin standalone first so it can set up Qt-specific dirs
+        /qt/tools/linuxdeploy-plugin-qt --appdir "$APPDIR"
+        # Then run linuxdeploy to bundle all remaining libs and finalize the AppDir
+        /qt/tools/linuxdeploy \\
+            --appdir "$APPDIR" \\
+            --plugin qt \\
+            --executable "$APPDIR/usr/bin/TrenchKit" \\
+            --desktop-file "$APPDIR/usr/share/applications/io.github.tapawingo.trenchkit.desktop" \\
+            --icon-file "$APPDIR/usr/share/icons/hicolor/256x256/apps/io.github.tapawingo.trenchkit.png"
 
-        # Launcher script (sets LD_LIBRARY_PATH and QT_PLUGIN_PATH)
-        cat > "$STAGE/TrenchKit.sh" << 'LAUNCHER'
-#!/bin/bash
-DIR="$(cd "$(dirname "$0")" && pwd)"
-export LD_LIBRARY_PATH="$DIR/lib:$LD_LIBRARY_PATH"
-export QT_PLUGIN_PATH="$DIR"
-exec "$DIR/TrenchKit" "$@"
-LAUNCHER
-        chmod +x "$STAGE/TrenchKit.sh"
-
-        echo "==> Creating archive /dist/{archive_name}..."
-        cd "$STAGE"
-        zip -ry "/dist/{archive_name}" .
+        echo "==> Building AppImage..."
+        ARCH=x86_64 /qt/tools/appimagetool "$APPDIR" "/dist/{archive_name}"
 
         echo "==> Done."
     """)
@@ -146,7 +139,7 @@ LAUNCHER
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Build a Linux release binary via Docker and package it into dist/."
+        description="Build a Linux AppImage via Docker and package it into dist/."
     )
     parser.add_argument(
         "--qt-version", default=DEFAULT_QT_VERSION,
@@ -158,7 +151,7 @@ def main() -> int:
     )
     parser.add_argument(
         "--reinstall-qt", action="store_true",
-        help="Delete the Qt cache volume and re-download Qt"
+        help="Delete the Qt cache volume and re-download Qt and AppImage tools"
     )
     args = parser.parse_args()
 
@@ -170,7 +163,7 @@ def main() -> int:
     qt_volume   = f"trenchkit-qt-{args.qt_version}"
     qt_dir      = f"/qt/{args.qt_version}/gcc_64"
 
-    # ── 1. Build Docker image (system packages + cmake + aqtinstall only) ───
+    # ── 1. Build Docker image ────────────────────────────────────────────────
     print(f"\n==> Building Docker image {IMAGE_TAG} ...\n")
     docker_build = [
         "docker", "build",
@@ -196,9 +189,18 @@ def main() -> int:
         "bash", "-c", qt_install_script(args.qt_version, qt_dir),
     ])
 
-    # ── 4. Build + package ───────────────────────────────────────────────────
+    # ── 4. Install AppImage tools into the same volume (skipped if cached) ───
+    print(f"\n==> Ensuring AppImage tools are in cache volume {qt_volume} ...\n")
+    run([
+        "docker", "run", "--rm",
+        "-v", f"{qt_volume}:/qt",
+        IMAGE_TAG,
+        "bash", "-c", tools_install_script(),
+    ])
+
+    # ── 5. Build + package ───────────────────────────────────────────────────
     version      = read_version(project_root)
-    archive_name = f"linux-{version}.zip"
+    archive_name = f"TrenchKit-{version}-x86_64.AppImage"
     archive_path = dist_dir / archive_name
 
     if archive_path.exists():
@@ -211,7 +213,7 @@ def main() -> int:
         "-v", f"{project_root}:/src:ro",
         "-v", f"{dist_dir}:/dist",
         IMAGE_TAG,
-        "bash", "-c", build_package_script(qt_dir, archive_name),
+        "bash", "-c", build_package_script(qt_dir, version, archive_name),
     ])
 
     print(f"\nPackaged release: {archive_path}")

--- a/tools/build_linux.py
+++ b/tools/build_linux.py
@@ -135,6 +135,10 @@ exec "$HERE/usr/bin/TrenchKit" "$@"
 RUNEOF
         chmod +x "$APPDIR/trenchkit.sh"
 
+        echo "==> Setting AppImage icon..."
+        cp "$APPDIR/usr/share/icons/hicolor/256x256/apps/io.github.tapawingo.trenchkit.png" \
+           "$APPDIR/.DirIcon"
+
         echo "==> Building AppImage..."
         VERSION="{version}" ARCH=x86_64 /qt/tools/appimagetool "$APPDIR" "/dist/{appimage_name}"
 
@@ -209,7 +213,7 @@ def main() -> int:
     # ── 5. Build + package ───────────────────────────────────────────────────
     version       = read_version(project_root)
     appimage_name = f"TrenchKit-{version}-x86_64.AppImage"
-    zip_name      = f"TrenchKit-{version}-linux-x86_64.zip"
+    zip_name      = f"linux-{version}.zip"
     appimage_path = dist_dir / appimage_name
     zip_path      = dist_dir / zip_name
 

--- a/tools/build_linux.py
+++ b/tools/build_linux.py
@@ -82,11 +82,11 @@ def tools_install_script() -> str:
     """)
 
 
-def build_package_script(qt_dir: str, version: str, archive_name: str) -> str:
-    """Configures, builds, and packages TrenchKit as an AppImage inside the container."""
+def build_package_script(qt_dir: str, version: str, appimage_name: str, zip_name: str) -> str:
+    """Configures, builds, and packages TrenchKit as an AppImage and zip inside the container."""
     return textwrap.dedent(f"""\
         set -e
-        export PATH="{qt_dir}/bin:$PATH"
+        export PATH="/qt/tools:{qt_dir}/bin:$PATH"
         export CMAKE_PREFIX_PATH="{qt_dir}"
         export APPIMAGE_EXTRACT_AND_RUN=1
 
@@ -108,30 +108,38 @@ def build_package_script(qt_dir: str, version: str, archive_name: str) -> str:
 
         cp /src/extras/linux/io.github.tapawingo.trenchkit.desktop \\
            "$APPDIR/usr/share/applications/"
-        cp /src/extras/logo/logo_transparent.png \\
-           "$APPDIR/usr/share/icons/hicolor/256x256/apps/io.github.tapawingo.trenchkit.png"
-
-        # TLS plugin — place it where Qt expects it inside the AppDir
-        TLS_SRC=/build/src/tls/libqopensslbackend.so
-        if [ -f "$TLS_SRC" ]; then
-            mkdir -p "$APPDIR/usr/plugins/tls"
-            cp "$TLS_SRC" "$APPDIR/usr/plugins/tls/"
-        fi
+        convert /src/extras/logo/logo_transparent.png \\
+            -resize 256x256 \\
+            "$APPDIR/usr/share/icons/hicolor/256x256/apps/io.github.tapawingo.trenchkit.png"
 
         echo "==> Running linuxdeploy with Qt plugin..."
         export QMAKE="{qt_dir}/bin/qmake"
-        # Run the Qt plugin standalone first so it can set up Qt-specific dirs
-        /qt/tools/linuxdeploy-plugin-qt --appdir "$APPDIR"
-        # Then run linuxdeploy to bundle all remaining libs and finalize the AppDir
         /qt/tools/linuxdeploy \\
             --appdir "$APPDIR" \\
             --plugin qt \\
             --executable "$APPDIR/usr/bin/TrenchKit" \\
+            --executable "$APPDIR/usr/bin/TrenchKitUpdater" \\
             --desktop-file "$APPDIR/usr/share/applications/io.github.tapawingo.trenchkit.desktop" \\
             --icon-file "$APPDIR/usr/share/icons/hicolor/256x256/apps/io.github.tapawingo.trenchkit.png"
 
+        echo "==> Adding run.sh launcher for zip distribution..."
+        cat > "$APPDIR/trenchkit.sh" << 'RUNEOF'
+#!/bin/sh
+# Launcher for the portable zip distribution of TrenchKit.
+# Sets LD_LIBRARY_PATH so the bundled Qt and XCB libs are used instead of
+# whatever (possibly older) versions the system has installed.
+HERE="$(cd "$(dirname "$0")" && pwd)"
+export LD_LIBRARY_PATH="$HERE/usr/lib:${{LD_LIBRARY_PATH:-}}"
+export QT_PLUGIN_PATH="$HERE/usr/plugins"
+exec "$HERE/usr/bin/TrenchKit" "$@"
+RUNEOF
+        chmod +x "$APPDIR/trenchkit.sh"
+
         echo "==> Building AppImage..."
-        ARCH=x86_64 /qt/tools/appimagetool "$APPDIR" "/dist/{archive_name}"
+        VERSION="{version}" ARCH=x86_64 /qt/tools/appimagetool "$APPDIR" "/dist/{appimage_name}"
+
+        echo "==> Building zip archive..."
+        (cd "$APPDIR" && zip -r "/dist/{zip_name}" .)
 
         echo "==> Done."
     """)
@@ -199,12 +207,15 @@ def main() -> int:
     ])
 
     # ── 5. Build + package ───────────────────────────────────────────────────
-    version      = read_version(project_root)
-    archive_name = f"TrenchKit-{version}-x86_64.AppImage"
-    archive_path = dist_dir / archive_name
+    version       = read_version(project_root)
+    appimage_name = f"TrenchKit-{version}-x86_64.AppImage"
+    zip_name      = f"TrenchKit-{version}-linux-x86_64.zip"
+    appimage_path = dist_dir / appimage_name
+    zip_path      = dist_dir / zip_name
 
-    if archive_path.exists():
-        archive_path.unlink()
+    for p in (appimage_path, zip_path):
+        if p.exists():
+            p.unlink()
 
     print(f"\n==> Building TrenchKit {version} ...\n")
     run([
@@ -213,10 +224,12 @@ def main() -> int:
         "-v", f"{project_root}:/src:ro",
         "-v", f"{dist_dir}:/dist",
         IMAGE_TAG,
-        "bash", "-c", build_package_script(qt_dir, version, archive_name),
+        "bash", "-c", build_package_script(qt_dir, version, appimage_name, zip_name),
     ])
 
-    print(f"\nPackaged release: {archive_path}")
+    print(f"\nPackaged releases:")
+    print(f"  {appimage_path}")
+    print(f"  {zip_path}")
     return 0
 
 

--- a/tools/build_linux.py
+++ b/tools/build_linux.py
@@ -84,7 +84,7 @@ def build_package_script(qt_dir: str, archive_name: str) -> str:
         TLS_SRC=/build/src/tls/libqopensslbackend.so
         [ -f "$TLS_SRC" ] && cp "$TLS_SRC" "$STAGE/tls/"
 
-        # xcb platform plugin
+        # xcb platform plugin (keep XCB_SRC for the ldd sweep below)
         XCB_SRC="{qt_dir}/plugins/platforms/libqxcb.so"
         [ -f "$XCB_SRC" ] && cp "$XCB_SRC" "$STAGE/platforms/"
 
@@ -99,15 +99,32 @@ def build_package_script(qt_dir: str, archive_name: str) -> str:
             [ -n "$src" ] && cp "$src" "$STAGE/lib/"
         done
 
-        # Also copy any Qt libs that the xcb plugin links against
+        # Sweep all Qt source libs for any deps Qt bundles in its own dir
+        # (covers ICU 73, libzstd, and anything else Qt ships alongside its modules)
+        for qt_src in "$QT_LIB_DIR"/libQt6*.so.*; do
+            [ -f "$qt_src" ] || continue
+            ldd "$qt_src" 2>/dev/null | awk '/=> \\// {{print $3}}' | while read -r dep; do
+                [[ "$dep" == /qt/* ]] || continue
+                base=$(basename "$dep")
+                [ -f "$dep" ] && [ ! -f "$STAGE/lib/$base" ] && cp "$dep" "$STAGE/lib/"
+            done
+        done
+        # Same sweep for the xcb plugin
         if [ -f "$STAGE/platforms/libqxcb.so" ]; then
-            ldd "$STAGE/platforms/libqxcb.so" 2>/dev/null \\
-                | awk '/=> \\/qt\\// {{print $3}}' \\
-                | while read -r dep; do
-                    base=$(basename "$dep")
-                    [ -f "$dep" ] && [ ! -f "$STAGE/lib/$base" ] && cp "$dep" "$STAGE/lib/"
-                done
+            ldd "$XCB_SRC" 2>/dev/null | awk '/=> \\// {{print $3}}' | while read -r dep; do
+                [[ "$dep" == /qt/* ]] || continue
+                base=$(basename "$dep")
+                [ -f "$dep" ] && [ ! -f "$STAGE/lib/$base" ] && cp "$dep" "$STAGE/lib/"
+            done
         fi
+
+        # Create SONAME symlinks (e.g. libQt6Core.so.6 -> libQt6Core.so.6.10.1)
+        # Without these the ELF loader cannot find the bundled libs and falls back to system Qt
+        for f in "$STAGE/lib/"*.so.*; do
+            [ -L "$f" ] && continue
+            soname=$(readelf -d "$f" 2>/dev/null | awk '/SONAME/ {{gsub(/[\\[\\]]/, "", $NF); print $NF}}')
+            [ -n "$soname" ] && [ ! -e "$STAGE/lib/$soname" ] && ln -sf "$(basename "$f")" "$STAGE/lib/$soname"
+        done
 
         # Launcher script (sets LD_LIBRARY_PATH and QT_PLUGIN_PATH)
         cat > "$STAGE/TrenchKit.sh" << 'LAUNCHER'
@@ -121,7 +138,7 @@ LAUNCHER
 
         echo "==> Creating archive /dist/{archive_name}..."
         cd "$STAGE"
-        zip -r "/dist/{archive_name}" .
+        zip -ry "/dist/{archive_name}" .
 
         echo "==> Done."
     """)

--- a/updater/main.cpp
+++ b/updater/main.cpp
@@ -371,6 +371,18 @@ int main(int argc, char **argv) {
     }
 #else
     const fs::path exePath = args.appDir / std::string(args.exeName.begin(), args.exeName.end());
+
+    // fs::copy_file does not preserve execute bits — set them explicitly.
+    {
+        std::error_code permEc;
+        fs::permissions(exePath,
+            fs::perms::owner_exec | fs::perms::group_exec | fs::perms::others_exec,
+            fs::perm_options::add, permEc);
+        if (permEc) {
+            logAndStderr(logDir, "Warning: failed to set executable permissions: " + permEc.message());
+        }
+    }
+
     appendLog(logDir, "Relaunching application: " + exePath.string());
     pid_t pid = fork();
     if (pid == 0) {

--- a/updater/main.cpp
+++ b/updater/main.cpp
@@ -9,7 +9,9 @@
 #include <windows.h>
 #include <shlobj.h>
 #else
+#include <cerrno>
 #include <unistd.h>
+#include <signal.h>
 #endif
 
 namespace fs = std::filesystem;
@@ -20,6 +22,11 @@ struct InstallArgs {
     fs::path newDir;
     fs::path updatesDir;
     std::wstring exeName;
+    // AppImage mode (Linux)
+    fs::path appImagePath;  ///< Path to the current AppImage file
+    fs::path newFilePath;   ///< Path to the new AppImage to install
+    // Cross-platform
+    int waitPid = 0;        ///< PID of main app to wait for before installing
 };
 
 static fs::path g_updatesDir;
@@ -88,27 +95,49 @@ static bool parseArgs(int argc, char **argv, InstallArgs &out) {
         } else if (arg == "--exe-name" && i + 1 < argc) {
             const std::string exe = argv[++i];
             out.exeName = std::wstring(exe.begin(), exe.end());
+        } else if (arg == "--appimage-path" && i + 1 < argc) {
+            out.appImagePath = fs::path(argv[++i]);
+        } else if (arg == "--new-file" && i + 1 < argc) {
+            out.newFilePath = fs::path(argv[++i]);
+        } else if (arg == "--pid" && i + 1 < argc) {
+            try { out.waitPid = std::stoi(argv[++i]); } catch (...) {}
         }
     }
-    return out.install && !out.appDir.empty() && !out.newDir.empty() && !out.exeName.empty();
+    const bool directoryMode = out.install && !out.appDir.empty()
+                                && !out.newDir.empty() && !out.exeName.empty();
+    const bool appImageMode  = out.install && !out.appImagePath.empty()
+                                && !out.newFilePath.empty();
+    return directoryMode || appImageMode;
 }
 
 #if defined(_WIN32)
-static void waitForAppExit(const fs::path &appDir) {
+static void waitForAppExit(const fs::path &appDir, int /*pid*/) {
     // Try to open the mutex created by the main app
-    // This blocks until the main app releases it (exits)
     HANDLE hMutex = OpenMutexW(SYNCHRONIZE, FALSE, L"Global\\TrenchKitRunning");
     if (hMutex) {
         appendLog(appDir, "Waiting for mutex release (app exit)...");
-        WaitForSingleObject(hMutex, 30000);  // 30 second timeout
+        WaitForSingleObject(hMutex, 30000);
         CloseHandle(hMutex);
         appendLog(appDir, "Mutex released, app has exited.");
     } else {
-        // Mutex doesn't exist = app already exited, or running old version without mutex
         appendLog(appDir, "Mutex not found, assuming app already exited.");
     }
-    // Brief delay for file handles to close
     Sleep(500);
+}
+#else
+static void waitForAppExit(const fs::path &logDir, int pid) {
+    if (pid > 0) {
+        appendLog(logDir, "Waiting for PID " + std::to_string(pid) + " to exit...");
+        for (int i = 0; i < 30; ++i) {
+            if (kill(static_cast<pid_t>(pid), 0) != 0 && errno == ESRCH)
+                break;
+            sleep(1);
+        }
+        appendLog(logDir, "Process exited (or timed out).");
+    } else {
+        appendLog(logDir, "No PID provided, waiting briefly...");
+        sleep(1);
+    }
 }
 #endif
 
@@ -238,8 +267,11 @@ static bool launchApp(const fs::path &appDir, const std::wstring &exeName) {
 int main(int argc, char **argv) {
     InstallArgs args;
     if (!parseArgs(argc, argv, args)) {
-        std::cerr << "Usage: TrenchKitUpdater --install --app-dir <dir> --new-dir <dir> "
-                     "--exe-name <name> [--updates-dir <dir>]\n";
+        std::cerr << "Usage:\n"
+                  << "  Directory mode: TrenchKitUpdater --install --app-dir <dir> --new-dir <dir> "
+                     "--exe-name <name> [--updates-dir <dir>] [--pid <pid>]\n"
+                  << "  AppImage mode:  TrenchKitUpdater --install --appimage-path <file> "
+                     "--new-file <file> [--updates-dir <dir>] [--pid <pid>]\n";
         return 1;
     }
     const fs::path helperName = helperExecutableName(argv[0]);
@@ -247,31 +279,81 @@ int main(int argc, char **argv) {
     if (!args.updatesDir.empty()) {
         g_updatesDir = args.updatesDir;
     }
-    appendLog(args.appDir, "Updater started.");
-    appendLog(args.appDir, "App dir: " + args.appDir.string());
-    appendLog(args.appDir, "New dir: " + args.newDir.string());
-    appendLog(args.appDir, "Exe name: " + std::string(args.exeName.begin(), args.exeName.end()));
+
+    // Determine a path to use for logging
+    const fs::path logDir = !args.appDir.empty() ? args.appDir
+                          : !args.appImagePath.empty() ? args.appImagePath.parent_path()
+                          : fs::path(".");
+
+    appendLog(logDir, "Updater started.");
+
+#if !defined(_WIN32)
+    // ── AppImage mode (Linux) ────────────────────────────────────────────────
+    if (!args.appImagePath.empty()) {
+        appendLog(logDir, "Mode: AppImage");
+        appendLog(logDir, "Current AppImage: " + args.appImagePath.string());
+        appendLog(logDir, "New AppImage:     " + args.newFilePath.string());
+
+        waitForAppExit(logDir, args.waitPid);
+
+        if (!fs::exists(args.newFilePath)) {
+            logAndStderr(logDir, "New AppImage not found: " + args.newFilePath.string());
+            return 1;
+        }
+
+        std::error_code ec;
+        // Prefer atomic rename (works when src and dst are on the same filesystem)
+        fs::rename(args.newFilePath, args.appImagePath, ec);
+        if (ec) {
+            appendLog(logDir, "rename failed (" + ec.message() + "), falling back to copy.");
+            ec.clear();
+            fs::copy_file(args.newFilePath, args.appImagePath,
+                          fs::copy_options::overwrite_existing, ec);
+            if (ec) {
+                logAndStderr(logDir, "Failed to replace AppImage: " + ec.message());
+                return 1;
+            }
+            fs::remove(args.newFilePath, ec);
+        }
+
+        // Ensure executable bit is set
+        fs::permissions(args.appImagePath,
+            fs::perms::owner_exec | fs::perms::group_exec | fs::perms::others_exec,
+            fs::perm_options::add, ec);
+
+        appendLog(logDir, "Update applied. Relaunching: " + args.appImagePath.string());
+        execl(args.appImagePath.c_str(), args.appImagePath.filename().c_str(), nullptr);
+        logAndStderr(logDir, "execl failed — please relaunch manually.");
+        return 1;
+    }
+#endif
+
+    // ── Directory mode ───────────────────────────────────────────────────────
+    appendLog(logDir, "Mode: directory");
+    appendLog(logDir, "App dir: " + args.appDir.string());
+    appendLog(logDir, "New dir: " + args.newDir.string());
+    appendLog(logDir, "Exe name: " + std::string(args.exeName.begin(), args.exeName.end()));
 
 #if defined(_WIN32)
-    waitForAppExit(args.appDir);
+    waitForAppExit(args.appDir, args.waitPid);
 #else
-    // On non-Windows, just wait briefly for the app to exit
-    // The app should have already quit before launching the updater
-    appendLog(args.appDir, "Waiting briefly for app to release files...");
-    sleep(1);
+    waitForAppExit(logDir, args.waitPid);
 #endif
 
     if (!fs::exists(args.newDir)) {
-        logAndStderr(args.appDir, "New version directory not found.");
+        logAndStderr(logDir, "New version directory not found.");
 #if defined(_WIN32)
         showErrorDialog(L"Update failed: new version directory not found.");
 #endif
         return 1;
     }
 
-    appendLog(args.appDir, "Copying new version files.");
+    appendLog(logDir, "Removing old app files.");
+    removeOldAppFiles(args.appDir, helperName);
+
+    appendLog(logDir, "Copying new version files.");
     if (!copyRecursive(args.newDir, args.appDir, helperName)) {
-        logAndStderr(args.appDir, "Failed to copy new version files.");
+        logAndStderr(logDir, "Failed to copy new version files.");
 #if defined(_WIN32)
         showErrorDialog(L"Update failed while copying new version files.");
 #endif
@@ -281,27 +363,24 @@ int main(int argc, char **argv) {
 #if defined(_WIN32)
     if (!launchApp(args.appDir, args.exeName)) {
         const fs::path exePath = args.appDir / args.exeName;
-        logAndStderr(args.appDir, "Failed to relaunch application.");
+        logAndStderr(logDir, "Failed to relaunch application.");
         const std::wstring message = L"Update applied, but TrenchKit failed to relaunch.\n"
                                      L"Please start it manually from:\n" + exePath.wstring();
         showErrorDialog(message);
         return 1;
     }
 #else
-    // Relaunch on non-Windows using fork + exec
     const fs::path exePath = args.appDir / std::string(args.exeName.begin(), args.exeName.end());
-    appendLog(args.appDir, "Relaunching application: " + exePath.string());
+    appendLog(logDir, "Relaunching application: " + exePath.string());
     pid_t pid = fork();
     if (pid == 0) {
-        // Child process - exec the app
         execl(exePath.c_str(), exePath.filename().c_str(), nullptr);
-        // If execl returns, it failed
         _exit(1);
     } else if (pid < 0) {
-        logAndStderr(args.appDir, "Failed to fork for relaunch.");
+        logAndStderr(logDir, "Failed to fork for relaunch.");
     }
 #endif
 
-    appendLog(args.appDir, "Update completed successfully.");
+    appendLog(logDir, "Update completed successfully.");
     return 0;
 }


### PR DESCRIPTION
## What does this PR do?

Closes #99

Adds a complete Linux build pipeline and fixes all Linux-specific issues across the codebase.

**Build & packaging (`tools/`)**
- New `build_linux.py` script that builds a self-contained AppImage and portable zip via Docker, with Qt and AppImage tools cached in a named volume for fast incremental builds
- New `Dockerfile.linux-builder` with all required build and runtime dependencies (XCB extension libs, libarchive compression headers, ImageMagick for icon resizing)
- Zip includes a `trenchkit.sh` launcher that sets `LD_LIBRARY_PATH`/`QT_PLUGIN_PATH` so bundled libs are used without system-wide installation
- Both outputs follow the project naming convention (`linux-{version}.zip`, `TrenchKit-{version}-x86_64.AppImage`)

**Updater (`updater/main.cpp`)**
- Added AppImage update mode: atomic rename/copy of new AppImage, sets exec bit, relaunches via `execl`
- Added `--pid` argument; Linux waits for the main process to exit via `kill(..., 0)` polling before installing
- Directory mode now sets exec bits on extracted binaries after `copyRecursive()` - `fs::copy_file` does not preserve them

**Mod manager (`src/core/managers/ModManager.cpp`)**
- Set `644` permissions on pak files after every `QFile::copy` to Foxhole's Paks directory (`copyModToPaks`, `renumberEnabledMods`) - Foxhole on Linux/Proton requires world-readable files

**Archive handling**
- `ArchiveExtractor`: normalise `\` → `/` in entry names so Windows-created archives extract correctly on Linux
- `UpdateArchiveExtractor`: same normalisation plus path-traversal protection (`..` and absolute entry paths are rejected)

**UI & platform (`src/`)**
- `TitleBar`: use `QWindow::startSystemMove()` for native Wayland/X11 drag with `window()->move()` fallback
- `MainWindow`: frameless window resize on Linux via `QWindow::startSystemResize()` with 8 px edge detection and resize cursors
- `LaunchWidget`: Linux launches Foxhole via `steam://run/1454690`; detects running game with `pgrep -f`
- `FoxholeDetector` / `InstallPathWidget`: Windows `.exe` scan paths guarded with `#ifdef Q_OS_WIN`
- `SettingsWidget`: AppImage shortcuts write `$APPIMAGE` path into `.desktop` files; MIME registration uses `QStandardPaths::GenericDataLocation` instead of hardcoded `~/.local/share`
- `ConflictDetailModalContent`: expanded monospace font stack to include `DejaVu Sans Mono` / `Liberation Mono` for Linux
- `MainWindow`: Linux AppImage update flow - downloads new AppImage directly, stages updater to `/tmp` before quit, passes `--appimage-path` / `--new-file` to updater

**Other**
- `Makefile`: OS-aware `EXE_EXT` so `run-debug`/`run-release` targets work on Linux
- `extras/linux/io.github.tapawingo.trenchkit.desktop`: correct `Icon=` field added

## How was it tested?

- AppImage built successfully via `build_linux.py` on Ubuntu 22.04 inside Docker
- Portable zip extracts and launches via `trenchkit.sh` with bundled libs
- Mod enable/disable verified on Linux - pak files readable by Proton/Foxhole
- Windows build unaffected (all Linux changes guarded with `#ifdef Q_OS_LINUX` / `#ifndef Q_OS_WIN`)

  ## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/Tapawingo/TrenchKit/blob/main/CONTRIBUTING.md)
- [x] PR title follows the format: `area - Add|Fix|Improve|Change|Make|Remove {changes}`