### PR TITLE
Mod updates - Fix itch.io updates detecting and installing the wrong variant

### DIFF
--- a/src/core/services/ItchModUpdateService.cpp
+++ b/src/core/services/ItchModUpdateService.cpp
@@ -126,22 +126,8 @@ void ItchModUpdateService::onUploadsReceived(const QList<ItchUploadInfo> &upload
     const ModInfo &mod = m_modsToCheck[m_currentModIndex];
     QDateTime currentDate = mod.uploadDate.isValid() ? mod.uploadDate : mod.installDate;
 
-    QList<ItchUploadInfo> candidateUploads;
-    if (!mod.itchUploadId.isEmpty()) {
-        // Only flag an update if the specific installed upload has a newer date
-        for (const ItchUploadInfo &upload : uploads) {
-            if (upload.id == mod.itchUploadId && !mod.ignoredItchUploadIds.contains(upload.id)) {
-                QDateTime uploadDate = upload.updatedAt.isValid() ? upload.updatedAt : upload.createdAt;
-                if (isUpdateAvailable(currentDate, uploadDate)) {
-                    candidateUploads.append(upload);
-                }
-                break;
-            }
-        }
-    } else {
-        // Legacy fallback: mod installed before upload ID tracking
-        candidateUploads = findCandidateUploads(uploads, currentDate, mod.ignoredItchUploadIds);
-    }
+    QList<ItchUploadInfo> candidateUploads =
+        findCandidateUploads(uploads, currentDate, mod.ignoredItchUploadIds);
 
     if (!candidateUploads.isEmpty()) {
         ItchUpdateInfo updateInfo(mod.id, mod.version, currentDate, candidateUploads);

--- a/src/modals/mod_manager/ItchModUpdateModalContent.h
+++ b/src/modals/mod_manager/ItchModUpdateModalContent.h
@@ -20,9 +20,11 @@ class QPushButton;
 /**
  * @brief Shown when the user requests an update for an itch.io-linked mod.
  *
- * If the @c ItchUpdateInfo has multiple candidate uploads, prompts the user
- * to choose one via @c FileSelectionModalContent before starting the download.
- * Otherwise immediately starts downloading on @c showEvent.
+ * Expects an already-resolved @c ItchUpdateInfo naming a single upload to
+ * install; if multiple candidate uploads exist, the caller
+ * (@c ModListWidget::onUpdateRequested) prompts the user to choose one via
+ * @c FileSelectionModalContent before this modal is constructed. Immediately
+ * starts downloading the resolved upload on @c showEvent.
  */
 class ItchModUpdateModalContent : public BaseModalContent {
     Q_OBJECT

--- a/src/views/mod_manager/ModListWidget.cpp
+++ b/src/views/mod_manager/ModListWidget.cpp
@@ -1198,17 +1198,24 @@ void ModListWidget::onUpdateRequested(const QString &modId) {
             connect(modal, &ItchModUpdateModalContent::accepted, this, finalizeItchUpdate);
             m_modalManager->showModal(modal);
         }
-        // If multiple uploads and no matching filename, show file selection modal
-        else if (updateInfo.hasMultipleUploads()) {
+        // No exact filename match: always let the user confirm/select from the
+        // candidates, even if there's only one, so we never silently swap them
+        // onto an unrelated variant of the mod.
+        else {
             QList<FileItem> fileItems;
             for (const ItchUploadInfo &upload : updateInfo.candidateUploads) {
                 fileItems.append({upload.id, upload.filename});
             }
 
+            QString promptText = updateInfo.hasMultipleUploads()
+                ? QString("Multiple update files are available for '%1'. Select one:").arg(mod.name)
+                : QString("An update file is available for '%1' that doesn't match your installed file. "
+                          "Select it to install, or ignore it:").arg(mod.name);
+
             auto *fileModal = new FileSelectionModalContent(
                 fileItems,
                 "Select Update File",
-                QString("Multiple update files are available for '%1'. Select one:").arg(mod.name),
+                promptText,
                 false,
                 true  // Show "Ignore These Updates" button
             );
@@ -1259,12 +1266,6 @@ void ModListWidget::onUpdateRequested(const QString &modId) {
             });
 
             m_modalManager->showModal(fileModal);
-        }
-        // Single upload, proceed directly
-        else {
-            auto *modal = new ItchModUpdateModalContent(mod, updateInfo, m_modManager, m_itchClient, m_modalManager);
-            connect(modal, &ItchModUpdateModalContent::accepted, this, finalizeItchUpdate);
-            m_modalManager->showModal(modal);
         }
     }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes two related bugs in itch.io mod update handling:

1. **Detection**: itch.io tracks updates as new uploads with new ids, not
   in-place file replacements. `ItchModUpdateService` was only checking
   whether the *same* upload id got a newer date, which itch.io never does —
   so real updates (new uploads, different ids) were never detected.
   Detection now scans all uploads for the mod's game and flags any whose
   date is newer than the installed one.

2. **Picker**: when exactly one newer upload was found, the file-selection
   picker was skipped entirely and that file was installed directly — even
   if it belonged to a different variant of the mod than the one installed.
   The picker (with an "Ignore These Updates" option) now always shows
   whenever the candidate's filename doesn't exactly match the installed
   file, whether there's one newer candidate or several, so we never
   silently swap the user onto an unrelated variant.

Closes #104

## How was it tested?

Manual testing against real itch.io mod page:
same-filename updates auto-install as before, differing-filename updates
(single or multiple candidates) now show the picker with the option to
select or ignore.

## Checklist

- [X] I have read and understood the [contribution guidelines](https://github.com/Tapawingo/TrenchKit/blob/main/CONTRIBUTING.md)
- [X] PR title follows the format: `area - Add|Fix|Improve|Change|Make|Remove {changes}`