### PR TITLE
Chore - Fix Windows Qt DLL/plugin deployment and drop unused bsdtar build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ FetchContent_Declare(
   GIT_TAG v3.7.4
 )
 
-set(ENABLE_TAR ON)
+set(ENABLE_TAR OFF)
 set(ENABLE_CPIO OFF)
 set(ENABLE_CAT OFF)
 set(ENABLE_TEST OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -194,15 +194,31 @@ add_custom_target(update_translation_template
 
 # Post-build: Copy platform-specific TLS backend
 set(QT_TLS_PLUGIN_DIR "${Qt6_DIR}/../../../plugins/tls")
+set(HAVE_TLS_PLUGIN FALSE)
 if(WIN32)
-    set(TLS_PLUGIN "qschannelbackend.dll")
+    if(EXISTS "${QT_TLS_PLUGIN_DIR}/qschannelbackendd.dll")
+        # MSVC-style Qt kits ship separate debug/release plugin builds, same
+        # as the Qt DLLs themselves; pick the variant matching the build config.
+        set(TLS_PLUGIN "$<$<CONFIG:Debug>:qschannelbackendd.dll>$<$<NOT:$<CONFIG:Debug>>:qschannelbackend.dll>")
+        set(HAVE_TLS_PLUGIN TRUE)
+    elseif(EXISTS "${QT_TLS_PLUGIN_DIR}/qschannelbackend.dll")
+        # Single-variant kits (e.g. MinGW) use the same plugin for all configs.
+        set(TLS_PLUGIN "qschannelbackend.dll")
+        set(HAVE_TLS_PLUGIN TRUE)
+    endif()
 elseif(APPLE)
     set(TLS_PLUGIN "libqsecuretransportbackend.dylib")
+    if(EXISTS "${QT_TLS_PLUGIN_DIR}/${TLS_PLUGIN}")
+        set(HAVE_TLS_PLUGIN TRUE)
+    endif()
 else()
     set(TLS_PLUGIN "libqopensslbackend.so")
+    if(EXISTS "${QT_TLS_PLUGIN_DIR}/${TLS_PLUGIN}")
+        set(HAVE_TLS_PLUGIN TRUE)
+    endif()
 endif()
 
-if(EXISTS "${QT_TLS_PLUGIN_DIR}/${TLS_PLUGIN}")
+if(HAVE_TLS_PLUGIN)
     add_custom_command(TARGET TrenchKit POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory
             $<TARGET_FILE_DIR:TrenchKit>/tls
@@ -234,28 +250,22 @@ if(WIN32)
         )
     endif()
 
-    # Qt DLLs
-    set(QT_BIN_DIR "${Qt6_DIR}/../../../bin")
-    set(QT_APP_DLLS "")
-    foreach(QT_DLL_NAME
-            Qt6Core.dll
-            Qt6Gui.dll
-            Qt6Widgets.dll
-            Qt6Network.dll
-            Qt6Concurrent.dll
-            Qt6WebSockets.dll)
-        if(EXISTS "${QT_BIN_DIR}/${QT_DLL_NAME}")
-            list(APPEND QT_APP_DLLS "${QT_BIN_DIR}/${QT_DLL_NAME}")
-        endif()
-    endforeach()
-    if(QT_APP_DLLS)
+    # Qt DLLs (copy each target's own imported DLL so the correct debug/release
+    # variant, e.g. Qt6Networkd.dll under MSVC Debug, is always copied)
+    foreach(QT_APP_TARGET
+            Qt6::Core
+            Qt6::Gui
+            Qt6::Widgets
+            Qt6::Network
+            Qt6::Concurrent
+            Qt6::WebSockets)
         add_custom_command(TARGET TrenchKit POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                ${QT_APP_DLLS}
+                $<TARGET_FILE:${QT_APP_TARGET}>
                 $<TARGET_FILE_DIR:TrenchKit>
-            COMMENT "Copying Qt DLLs to output directory"
+            COMMENT "Copying $<TARGET_FILE_NAME:${QT_APP_TARGET}> to output directory"
         )
-    endif()
+    endforeach()
 
     # MinGW runtime DLLs
     if(MINGW)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,25 +45,18 @@ if(WIN32)
     )
   endif()
 
-  set(QT_BIN_DIR "${Qt6_DIR}/../../../bin")
-  set(QT_TEST_DLLS "")
-  foreach(QT_DLL_NAME
-          Qt6Core.dll
-          Qt6Test.dll
-          Qt6Network.dll
-          Qt6Concurrent.dll)
-    if(EXISTS "${QT_BIN_DIR}/${QT_DLL_NAME}")
-      list(APPEND QT_TEST_DLLS "${QT_BIN_DIR}/${QT_DLL_NAME}")
-    endif()
-  endforeach()
-  if(QT_TEST_DLLS)
+  foreach(QT_TEST_TARGET
+          Qt6::Core
+          Qt6::Test
+          Qt6::Network
+          Qt6::Concurrent)
     add_custom_command(TARGET tests_utilities POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${QT_TEST_DLLS}
+        $<TARGET_FILE:${QT_TEST_TARGET}>
         $<TARGET_FILE_DIR:tests_utilities>
-      COMMENT "Copying Qt DLLs for tests_utilities"
+      COMMENT "Copying $<TARGET_FILE_NAME:${QT_TEST_TARGET}> for tests_utilities"
     )
-  endif()
+  endforeach()
 
   if(MINGW)
     get_filename_component(MINGW_BIN_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
@@ -108,20 +101,14 @@ target_link_libraries(tests_mod_manifest
 add_test(NAME tests_mod_manifest COMMAND tests_mod_manifest)
 
 if(WIN32)
-  set(QT_MANIFEST_TEST_DLLS "")
-  foreach(QT_DLL_NAME Qt6Core.dll Qt6Test.dll)
-    if(EXISTS "${QT_BIN_DIR}/${QT_DLL_NAME}")
-      list(APPEND QT_MANIFEST_TEST_DLLS "${QT_BIN_DIR}/${QT_DLL_NAME}")
-    endif()
-  endforeach()
-  if(QT_MANIFEST_TEST_DLLS)
+  foreach(QT_TEST_TARGET Qt6::Core Qt6::Test)
     add_custom_command(TARGET tests_mod_manifest POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${QT_MANIFEST_TEST_DLLS}
+        $<TARGET_FILE:${QT_TEST_TARGET}>
         $<TARGET_FILE_DIR:tests_mod_manifest>
-      COMMENT "Copying Qt DLLs for tests_mod_manifest"
+      COMMENT "Copying $<TARGET_FILE_NAME:${QT_TEST_TARGET}> for tests_mod_manifest"
     )
-  endif()
+  endforeach()
 endif()
 
 qt_add_executable(tests_ts_translator
@@ -143,20 +130,14 @@ target_link_libraries(tests_ts_translator
 add_test(NAME tests_ts_translator COMMAND tests_ts_translator)
 
 if(WIN32)
-  set(QT_TS_TEST_DLLS "")
-  foreach(QT_DLL_NAME Qt6Core.dll Qt6Test.dll)
-    if(EXISTS "${QT_BIN_DIR}/${QT_DLL_NAME}")
-      list(APPEND QT_TS_TEST_DLLS "${QT_BIN_DIR}/${QT_DLL_NAME}")
-    endif()
-  endforeach()
-  if(QT_TS_TEST_DLLS)
+  foreach(QT_TEST_TARGET Qt6::Core Qt6::Test)
     add_custom_command(TARGET tests_ts_translator POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${QT_TS_TEST_DLLS}
+        $<TARGET_FILE:${QT_TEST_TARGET}>
         $<TARGET_FILE_DIR:tests_ts_translator>
-      COMMENT "Copying Qt DLLs for tests_ts_translator"
+      COMMENT "Copying $<TARGET_FILE_NAME:${QT_TEST_TARGET}> for tests_ts_translator"
     )
-  endif()
+  endforeach()
 endif()
 
 add_test(


### PR DESCRIPTION
## What does this PR do?

Fixes Windows post-build DLL/plugin deployment, which hardcoded release-named
Qt DLLs (`Qt6Network.dll`, etc.) and copied whichever one existed regardless
of build config. Under MSVC Debug builds, Qt ships separate debug-suffixed
DLLs (`Qt6Networkd.dll`) that the exe actually imports by that exact name,
the old script silently copied the wrong (release) variant, producing
"missing DLL" / "procedure entry point not found" errors at runtime. Same
issue existed for the TLS backend plugin (`qschannelbackend(d).dll`).

Both now copy each Qt target's own resolved output (`$<TARGET_FILE:...>`)
instead of a hand-maintained filename list, so the correct variant is always
copied, MSVC debug/release split or MinGW's single-variant kit alike.

Also disables libarchive's `ENABLE_TAR` option: the bundled `bsdtar` CLI
isn't used anywhere in this project and fails to link on toolchains without
a POSIX regex implementation available (hit this on a plain MinGW setup with
no PCRE/PCRE2 installed). Building only the `archive` library we actually
need sidesteps it.

## How was it tested?

Built and ran locally on Windows with both MSVC (`msvc2022_64` Qt kit) and
MinGW (`mingw_64` Qt kit) toolchains; confirmed the app launches without
missing-DLL errors on both, and `ctest` targets link and copy their Qt test
DLLs correctly.

## Checklist

- [X] I have read and understood the [contribution guidelines](https://github.com/Tapawingo/TrenchKit/blob/main/CONTRIBUTING.md)
- [X] PR title follows the format: `area - Add|Fix|Improve|Change|Make|Remove {changes}`