### PR TITLE
Updater - Fix self-update deleting user-added files next to the exe

### DIFF
--- a/updater/main.cpp
+++ b/updater/main.cpp
@@ -295,23 +295,44 @@ static bool copyRecursive(const fs::path &from, const fs::path &to, const fs::pa
     return true;
 }
 
-static void removeOldAppFiles(const fs::path &appDir, const fs::path &helperName) {
+static void removeOldAppFiles(const fs::path &appDir, const fs::path &newDir, const fs::path &helperName) {
     std::error_code ec;
+
+    // Only remove entries that are actually part of the new release, so any
+    // file or folder the user added next to the exe (e.g. a locally-tested
+    // `locales/` folder, see src/locales/TRANSLATING.md) survives an update.
+    std::vector<fs::path> newVersionEntries;
+    for (const auto &entry : fs::directory_iterator(newDir, ec)) {
+        newVersionEntries.push_back(entry.path().filename());
+    }
+    auto isShipped = [&](const fs::path &name) {
+        for (const auto &shipped : newVersionEntries) {
+#if defined(_WIN32)
+            if (equalsIgnoreCase(name.wstring(), shipped.wstring())) return true;
+#else
+            if (name == shipped) return true;
+#endif
+        }
+        return false;
+    };
+
     for (const auto &entry : fs::directory_iterator(appDir)) {
         const fs::path name = entry.path().filename();
-#if defined(_WIN32)
-        const std::wstring entryName = name.wstring();
-        if (equalsIgnoreCase(entryName, helperName.wstring())) {
+        if (isHelperExecutable(name, helperName)) {
             continue;
         }
-        if (equalsIgnoreCase(entryName, L"updates")) {
+#if defined(_WIN32)
+        if (equalsIgnoreCase(name.wstring(), L"updates")) {
             continue;
         }
 #else
-        if (name == helperName || name == "updates") {
+        if (name == "updates") {
             continue;
         }
 #endif
+        if (!isShipped(name)) {
+            continue;
+        }
         fs::remove_all(entry.path(), ec);
         if (ec) {
             appendLog(appDir, "Failed to remove " + entry.path().string() + ": " + ec.message(),
@@ -442,7 +463,7 @@ int main(int argc, char **argv) {
     }
 
     appendLog(logDir, "Removing old app files.");
-    removeOldAppFiles(args.appDir, helperName);
+    removeOldAppFiles(args.appDir, args.newDir, helperName);
 
     appendLog(logDir, "Copying new version files.");
     if (!copyRecursive(args.newDir, args.appDir, helperName)) {


### PR DESCRIPTION
## What does this PR do?

Fixes `removeOldAppFiles()` in the standalone updater helper, which cleared
the app directory with a blocklist (delete everything except the helper exe
and an `updates/` folder) before installing a new version. Since release
builds never ship a `locales/` folder — translations are bundled into the
binary as `.qm` resources — any file or folder a user added next to
`TrenchKit.exe` was silently destroyed on every self-update and never
restored. This was reported by a translation contributor who lost their
locally-tested `locales/` folder (the exact workflow documented in
`src/locales/TRANSLATING.md`) after installing an update.

Switches to an allowlist: an entry in the app directory is only removed if
that same name also exists in the staged new-version directory, so shipped
app files (exe, DLLs, `platforms/`, `tls/`) still get cleanly replaced while
anything the user added — a test `locales/` folder, saved configs, leftover
mod archives — survives.

## How was it tested?

Built the `updater` target and manually simulated an install: a fake app
directory with a `locales/` folder plus old exe/DLL, and a new-version
directory with updated files. Confirmed after running
`TrenchKitUpdater.exe --install ...` that the shipped files were correctly
replaced with new content while `locales/` was left completely untouched.

## Checklist

- [X] I have read and understood the [contribution guidelines](https://github.com/Tapawingo/TrenchKit/blob/main/CONTRIBUTING.md)
- [X] PR title follows the format: `area - Add|Fix|Improve|Change|Make|Remove {changes}`